### PR TITLE
feat: Add ID ranking feature to search system

### DIFF
--- a/search-crawler/migrations/20250717203317_add_id_index.sql
+++ b/search-crawler/migrations/20250717203317_add_id_index.sql
@@ -1,0 +1,5 @@
+-- Add index on id column for ranking performance
+CREATE INDEX IF NOT EXISTS idx_res_id ON res(id) WHERE id IS NOT NULL AND id != '';
+
+-- Add composite index for id and datetime (optional, for better performance)
+CREATE INDEX IF NOT EXISTS idx_res_id_datetime ON res(id, datetime) WHERE id IS NOT NULL AND id != '';

--- a/search/backend/adapter/src/database/model/mod.rs
+++ b/search/backend/adapter/src/database/model/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/adapter/src/database/model/ranking.rs
+++ b/search/backend/adapter/src/database/model/ranking.rs
@@ -1,0 +1,27 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use kernel::model::ranking::RankingEntry;
+
+#[derive(sqlx::FromRow)]
+pub struct RankingEntryRow {
+    pub rank: i64,
+    pub id: String,
+    pub post_count: i64,
+    pub latest_post_no: i32,
+    pub latest_post_datetime: NaiveDateTime,
+    pub first_post_no: i32,
+    pub first_post_datetime: NaiveDateTime,
+}
+
+impl RankingEntryRow {
+    pub fn into_ranking_entry(self) -> RankingEntry {
+        RankingEntry {
+            rank: self.rank,
+            id: self.id,
+            post_count: self.post_count,
+            latest_post_no: self.latest_post_no,
+            latest_post_datetime: DateTime::<Utc>::from_naive_utc_and_offset(self.latest_post_datetime, Utc),
+            first_post_no: self.first_post_no,
+            first_post_datetime: DateTime::<Utc>::from_naive_utc_and_offset(self.first_post_datetime, Utc),
+        }
+    }
+}

--- a/search/backend/adapter/src/repository/mod.rs
+++ b/search/backend/adapter/src/repository/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/adapter/src/repository/ranking.rs
+++ b/search/backend/adapter/src/repository/ranking.rs
@@ -1,0 +1,138 @@
+use async_trait::async_trait;
+use derive_new::new;
+use kernel::{
+    model::ranking::{RankingData, RankingEntry, RankingOptions, RankingSearchConditions, RankingType},
+    repository::ranking::RankingRepository,
+};
+use shared::error::{AppError, AppResult};
+
+use crate::database::model::ranking::RankingEntryRow;
+use crate::database::ConnectionPool;
+
+#[derive(new)]
+pub struct RankingRepositoryImpl {
+    db: ConnectionPool,
+}
+
+#[async_trait]
+impl RankingRepository for RankingRepositoryImpl {
+    async fn get_ranking(&self, options: RankingOptions) -> AppResult<RankingData> {
+        let mut query = r#"
+            WITH ranked_ids AS (
+                SELECT 
+                    id,
+                    COUNT(*) as post_count,
+                    MAX(no) as latest_post_no,
+                    MAX(datetime) as latest_post_datetime,
+                    MIN(no) as first_post_no,
+                    MIN(datetime) as first_post_datetime
+                FROM res
+                WHERE id IS NOT NULL AND id != ''
+        "#.to_string();
+
+        // Build dynamic WHERE conditions
+        let mut where_conditions = vec![];
+        let mut bind_values: Vec<String> = vec![];
+        let mut bind_index = 1;
+
+        if let Some(id) = &options.id {
+            where_conditions.push(format!("id LIKE ${}::text", bind_index));
+            bind_values.push(format!("%{}%", id));
+            bind_index += 1;
+        }
+        
+        if let Some(main_text) = &options.main_text {
+            where_conditions.push(format!("main_text LIKE ${}::text", bind_index));
+            bind_values.push(format!("%{}%", main_text));
+            bind_index += 1;
+        }
+        
+        if let Some(name_and_trip) = &options.name_and_trip {
+            where_conditions.push(format!("name_and_trip LIKE ${}::text", bind_index));
+            bind_values.push(format!("%{}%", name_and_trip));
+            bind_index += 1;
+        }
+        
+        if let Some(true) = options.oekaki {
+            where_conditions.push("oekaki_id IS NOT NULL".to_string());
+        }
+        
+        if let Some(date_range) = &options.date_range {
+            if let Some(since) = &date_range.since {
+                where_conditions.push(format!("datetime >= ${}::timestamp", bind_index));
+                bind_values.push(since.naive_utc().to_string());
+                bind_index += 1;
+            }
+            if let Some(until) = &date_range.until {
+                where_conditions.push(format!("datetime <= ${}::timestamp", bind_index));
+                bind_values.push(until.naive_utc().to_string());
+                bind_index += 1;
+            }
+        }
+        
+        if !where_conditions.is_empty() {
+            query.push_str(&format!(" AND {}", where_conditions.join(" AND ")));
+        }
+        
+        query.push_str(&format!(
+            r#"
+                GROUP BY id
+                HAVING COUNT(*) >= ${}
+            )
+            SELECT 
+                ROW_NUMBER() OVER (ORDER BY {} DESC) as rank,
+                id,
+                post_count,
+                latest_post_no,
+                latest_post_datetime,
+                first_post_no,
+                first_post_datetime
+            FROM ranked_ids
+            ORDER BY {} DESC
+            "#,
+            bind_index,
+            match &options.ranking_type {
+                RankingType::PostCount => "post_count",
+                RankingType::RecentActivity => "latest_post_datetime",
+            },
+            match &options.ranking_type {
+                RankingType::PostCount => "post_count",
+                RankingType::RecentActivity => "latest_post_datetime",
+            }
+        ));
+
+        // Build the query dynamically
+        let mut sql_query = sqlx::query_as::<_, RankingEntryRow>(&query);
+        
+        // Bind values in order
+        for value in &bind_values {
+            sql_query = sql_query.bind(value);
+        }
+        
+        // Bind min_posts last
+        sql_query = sql_query.bind(options.min_posts);
+
+        let rows = sql_query.fetch_all(self.db.inner_ref()).await
+            .map_err(AppError::SpecificOperationError)?;
+        
+        let total_unique_ids = rows.len() as i64;
+        let ranking: Vec<RankingEntry> = rows.into_iter()
+            .map(|row| row.into_ranking_entry())
+            .collect();
+
+        let search_conditions = RankingSearchConditions {
+            id: options.id.clone(),
+            main_text: options.main_text.clone(),
+            name_and_trip: options.name_and_trip.clone(),
+            oekaki: options.oekaki,
+            since: options.date_range.as_ref().and_then(|dr| dr.since.map(|dt| dt.to_rfc3339())),
+            until: options.date_range.as_ref().and_then(|dr| dr.until.map(|dt| dt.to_rfc3339())),
+        };
+
+        Ok(RankingData {
+            ranking,
+            total_unique_ids,
+            search_conditions,
+        })
+    }
+}

--- a/search/backend/adapter/src/repository/ranking.rs
+++ b/search/backend/adapter/src/repository/ranking.rs
@@ -28,6 +28,7 @@ impl RankingRepository for RankingRepositoryImpl {
                     MIN(datetime) as first_post_datetime
                 FROM res
                 WHERE id IS NOT NULL AND id != ''
+                AND datetime != '1970-01-01 00:00:00'::timestamp
         "#.to_string();
 
         // Build dynamic WHERE conditions
@@ -125,6 +126,7 @@ impl RankingRepository for RankingRepositoryImpl {
             SELECT COUNT(*) as count
             FROM res
             WHERE id IS NOT NULL AND id != ''
+            AND datetime != '1970-01-01 00:00:00'::timestamp
         "#.to_string();
 
         if !where_conditions.is_empty() {

--- a/search/backend/api/src/handler/mod.rs
+++ b/search/backend/api/src/handler/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/api/src/handler/ranking.rs
+++ b/search/backend/api/src/handler/ranking.rs
@@ -1,0 +1,19 @@
+use axum::extract::{Query, State};
+use axum::Json;
+use registry::AppRegistry;
+use shared::error::AppResult;
+
+use crate::model::ranking::{RankingRequest, RankingResponse};
+
+pub async fn get_ranking(
+    State(registry): State<AppRegistry>,
+    Query(req): Query<RankingRequest>,
+) -> AppResult<Json<RankingResponse>> {
+    let ranking_options = req.try_into()?;
+    let ranking_data = registry
+        .ranking_repository()
+        .get_ranking(ranking_options)
+        .await?;
+    
+    Ok(Json(ranking_data.into()))
+}

--- a/search/backend/api/src/model/mod.rs
+++ b/search/backend/api/src/model/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/api/src/model/ranking.rs
+++ b/search/backend/api/src/model/ranking.rs
@@ -112,6 +112,7 @@ impl TryFrom<RankingRequest> for RankingOptions {
 pub struct RankingResponse {
     pub ranking: Vec<RankingItem>,
     pub total_unique_ids: i64,
+    pub total_res_count: i64,
     pub search_conditions: SearchConditions,
 }
 
@@ -156,6 +157,7 @@ impl From<RankingData> for RankingResponse {
         RankingResponse {
             ranking,
             total_unique_ids: data.total_unique_ids,
+            total_res_count: data.total_res_count,
             search_conditions,
         }
     }

--- a/search/backend/api/src/model/ranking.rs
+++ b/search/backend/api/src/model/ranking.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use kernel::model::ranking::{
-    DateTimeRange, RankingData, RankingEntry, RankingOptions, RankingSearchConditions,
+    DateTimeRange, RankingData, RankingEntry, RankingOptions,
     RankingType as KernelRankingType,
 };
 use serde::{Deserialize, Deserializer, Serialize};

--- a/search/backend/api/src/model/ranking.rs
+++ b/search/backend/api/src/model/ranking.rs
@@ -1,0 +1,175 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use kernel::model::ranking::{
+    DateTimeRange, RankingData, RankingEntry, RankingOptions, RankingSearchConditions, RankingType,
+};
+use serde::{Deserialize, Deserializer, Serialize};
+use shared::error::{AppError, AppResult};
+
+#[derive(Debug, Deserialize)]
+pub struct RankingRequest {
+    pub id: Option<String>,
+    pub main_text: Option<String>,
+    pub name_and_trip: Option<String>,
+    pub oekaki: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_date")]
+    pub since: Option<NaiveDate>,
+    #[serde(default, deserialize_with = "deserialize_date")]
+    pub until: Option<NaiveDate>,
+    #[serde(default = "default_ranking_type")]
+    pub ranking_type: RankingType,
+    #[serde(default = "default_min_posts")]
+    pub min_posts: i32,
+}
+
+fn default_ranking_type() -> RankingType {
+    RankingType::PostCount
+}
+
+fn default_min_posts() -> i32 {
+    1
+}
+
+fn deserialize_date<'de, D>(de: D) -> Result<Option<NaiveDate>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(de)?;
+    const FORMAT: &str = "%Y-%m-%d";
+    match opt.as_deref() {
+        None | Some("") => Ok(None),
+        Some(s) => NaiveDate::parse_from_str(s, FORMAT)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+impl<'de> Deserialize<'de> for RankingType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "post_count" => Ok(RankingType::PostCount),
+            "recent_activity" => Ok(RankingType::RecentActivity),
+            _ => Err(serde::de::Error::custom("Invalid ranking type")),
+        }
+    }
+}
+
+impl Serialize for RankingType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            RankingType::PostCount => serializer.serialize_str("post_count"),
+            RankingType::RecentActivity => serializer.serialize_str("recent_activity"),
+        }
+    }
+}
+
+impl TryFrom<RankingRequest> for RankingOptions {
+    type Error = AppError;
+
+    fn try_from(req: RankingRequest) -> AppResult<Self> {
+        let date_range = match (req.since, req.until) {
+            (None, None) => None,
+            (since, until) => {
+                let since_dt = since.map(|d| {
+                    DateTime::<Utc>::from_naive_utc_and_offset(
+                        d.and_hms_opt(0, 0, 0).unwrap(),
+                        Utc,
+                    )
+                });
+                let until_dt = until.map(|d| {
+                    DateTime::<Utc>::from_naive_utc_and_offset(
+                        d.and_hms_opt(23, 59, 59).unwrap(),
+                        Utc,
+                    )
+                });
+                Some(DateTimeRange {
+                    since: since_dt,
+                    until: until_dt,
+                })
+            }
+        };
+
+        Ok(RankingOptions {
+            id: req.id,
+            main_text: req.main_text,
+            name_and_trip: req.name_and_trip,
+            oekaki: req.oekaki,
+            date_range,
+            ranking_type: req.ranking_type,
+            min_posts: req.min_posts,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RankingResponse {
+    pub ranking: Vec<RankingItem>,
+    pub total_unique_ids: i64,
+    pub search_conditions: SearchConditions,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RankingItem {
+    pub rank: i64,
+    pub id: String,
+    pub post_count: i64,
+    pub latest_post_no: i32,
+    pub latest_post_datetime: String,
+    pub first_post_no: i32,
+    pub first_post_datetime: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchConditions {
+    pub id: Option<String>,
+    pub main_text: Option<String>,
+    pub name_and_trip: Option<String>,
+    pub oekaki: Option<bool>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+impl From<RankingData> for RankingResponse {
+    fn from(data: RankingData) -> Self {
+        let ranking = data
+            .ranking
+            .into_iter()
+            .map(|entry| RankingItem::from(entry))
+            .collect();
+
+        let search_conditions = SearchConditions {
+            id: data.search_conditions.id,
+            main_text: data.search_conditions.main_text,
+            name_and_trip: data.search_conditions.name_and_trip,
+            oekaki: data.search_conditions.oekaki,
+            since: data.search_conditions.since,
+            until: data.search_conditions.until,
+        };
+
+        RankingResponse {
+            ranking,
+            total_unique_ids: data.total_unique_ids,
+            search_conditions,
+        }
+    }
+}
+
+impl From<RankingEntry> for RankingItem {
+    fn from(entry: RankingEntry) -> Self {
+        RankingItem {
+            rank: entry.rank,
+            id: entry.id,
+            post_count: entry.post_count,
+            latest_post_no: entry.latest_post_no,
+            latest_post_datetime: entry.latest_post_datetime.to_rfc3339(),
+            first_post_no: entry.first_post_no,
+            first_post_datetime: entry.first_post_datetime.to_rfc3339(),
+        }
+    }
+}

--- a/search/backend/api/src/route/mod.rs
+++ b/search/backend/api/src/route/mod.rs
@@ -1,2 +1,3 @@
 pub mod v1;
+pub mod ranking;
 pub mod search;

--- a/search/backend/api/src/route/ranking.rs
+++ b/search/backend/api/src/route/ranking.rs
@@ -1,0 +1,9 @@
+use axum::{routing::get, Router};
+use registry::AppRegistry;
+
+use crate::handler::ranking::get_ranking;
+
+pub fn build_ranking_router() -> Router<AppRegistry> {
+    Router::new()
+        .route("/ranking", get(get_ranking))
+}

--- a/search/backend/api/src/route/v1.rs
+++ b/search/backend/api/src/route/v1.rs
@@ -1,10 +1,13 @@
 use axum::Router;
 use registry::AppRegistry;
 
+use crate::route::ranking::build_ranking_router;
 use crate::route::search::build_search_router;
 
 pub fn route() -> Router<AppRegistry> {
-    let router = Router::new().merge(build_search_router());
+    let router = Router::new()
+        .merge(build_search_router())
+        .merge(build_ranking_router());
 
     Router::new().nest("/api/v1", router)
 }

--- a/search/backend/kernel/src/model/mod.rs
+++ b/search/backend/kernel/src/model/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/kernel/src/model/ranking/mod.rs
+++ b/search/backend/kernel/src/model/ranking/mod.rs
@@ -1,0 +1,66 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone)]
+pub struct RankingOptions {
+    pub id: Option<String>,
+    pub main_text: Option<String>,
+    pub name_and_trip: Option<String>,
+    pub oekaki: Option<bool>,
+    pub date_range: Option<DateTimeRange>,
+    pub ranking_type: RankingType,
+    pub min_posts: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct DateTimeRange {
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RankingType {
+    PostCount,
+    RecentActivity,
+}
+
+#[derive(Debug, Clone)]
+pub struct RankingData {
+    pub ranking: Vec<RankingEntry>,
+    pub total_unique_ids: i64,
+    pub search_conditions: RankingSearchConditions,
+}
+
+#[derive(Debug, Clone)]
+pub struct RankingEntry {
+    pub rank: i64,
+    pub id: String,
+    pub post_count: i64,
+    pub latest_post_no: i32,
+    pub latest_post_datetime: DateTime<Utc>,
+    pub first_post_no: i32,
+    pub first_post_datetime: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RankingSearchConditions {
+    pub id: Option<String>,
+    pub main_text: Option<String>,
+    pub name_and_trip: Option<String>,
+    pub oekaki: Option<bool>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+impl Default for RankingOptions {
+    fn default() -> Self {
+        Self {
+            id: None,
+            main_text: None,
+            name_and_trip: None,
+            oekaki: None,
+            date_range: None,
+            ranking_type: RankingType::PostCount,
+            min_posts: 1,
+        }
+    }
+}

--- a/search/backend/kernel/src/model/ranking/mod.rs
+++ b/search/backend/kernel/src/model/ranking/mod.rs
@@ -27,6 +27,7 @@ pub enum RankingType {
 pub struct RankingData {
     pub ranking: Vec<RankingEntry>,
     pub total_unique_ids: i64,
+    pub total_res_count: i64,
     pub search_conditions: RankingSearchConditions,
 }
 

--- a/search/backend/kernel/src/repository/mod.rs
+++ b/search/backend/kernel/src/repository/mod.rs
@@ -1,1 +1,2 @@
+pub mod ranking;
 pub mod search;

--- a/search/backend/kernel/src/repository/ranking.rs
+++ b/search/backend/kernel/src/repository/ranking.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+use shared::error::AppResult;
+
+use crate::model::ranking::{RankingData, RankingOptions};
+
+#[async_trait]
+pub trait RankingRepository: Send + Sync {
+    async fn get_ranking(&self, options: RankingOptions) -> AppResult<RankingData>;
+}

--- a/search/backend/registry/src/lib.rs
+++ b/search/backend/registry/src/lib.rs
@@ -1,22 +1,30 @@
 use std::sync::Arc;
 
 use adapter::database::ConnectionPool;
+use adapter::repository::ranking::RankingRepositoryImpl;
 use adapter::repository::search::SearchRepositoryImpl;
+use kernel::repository::ranking::RankingRepository;
 use kernel::repository::search::SearchRepository;
 
 #[derive(Clone)]
 pub struct AppRegistry {
     pub search_repository: Arc<dyn SearchRepository>,
+    pub ranking_repository: Arc<dyn RankingRepository>,
 }
 
 impl AppRegistry {
     pub fn new(pool: ConnectionPool) -> Self {
         Self {
             search_repository: Arc::new(SearchRepositoryImpl::new(pool.clone())),
+            ranking_repository: Arc::new(RankingRepositoryImpl::new(pool.clone())),
         }
     }
 
     pub fn search_repository(&self) -> Arc<dyn SearchRepository> {
         self.search_repository.clone()
+    }
+
+    pub fn ranking_repository(&self) -> Arc<dyn RankingRepository> {
+        self.ranking_repository.clone()
     }
 }

--- a/search/frontend/src/App.tsx
+++ b/search/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import Search from "./pages/Search";
 import Oekaki from "./pages/Oekaki";
+import Ranking from "./pages/Ranking";
 
 export default function App() {
   const router = createBrowserRouter(
@@ -13,6 +14,7 @@ export default function App() {
       <Route>
         <Route path="/" element={<Search />} />
         <Route path="/oekaki" element={<Oekaki />} />
+        <Route path="/ranking" element={<Ranking />} />
       </Route>,
     ),
   );

--- a/search/frontend/src/components/Header.tsx
+++ b/search/frontend/src/components/Header.tsx
@@ -36,7 +36,7 @@ export function Header() {
                 to="/ranking"
                 className={getLinkClassName("/ranking")}
               >
-                ランキング
+                IDランキング
               </Link>
             </div>
           </div>

--- a/search/frontend/src/components/Header.tsx
+++ b/search/frontend/src/components/Header.tsx
@@ -1,6 +1,19 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 export function Header() {
+  const location = useLocation();
+  
+  const isActive = (path: string) => {
+    return location.pathname === path;
+  };
+  
+  const getLinkClassName = (path: string) => {
+    const baseClass = "inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium";
+    return isActive(path)
+      ? `${baseClass} border-blue-500 text-gray-900`
+      : `${baseClass} border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300`;
+  };
+  
   return (
     <header className="bg-white shadow-md">
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -9,15 +22,21 @@ export function Header() {
             <div className="flex space-x-8">
               <Link
                 to="/"
-                className="inline-flex items-center px-1 pt-1 text-gray-500 hover:text-gray-700"
+                className={getLinkClassName("/")}
               >
                 掲示板検索
               </Link>
               <Link
                 to="/oekaki"
-                className="inline-flex items-center px-1 pt-1 text-gray-500 hover:text-gray-700"
+                className={getLinkClassName("/oekaki")}
               >
                 お絵かきをまとめる機械
+              </Link>
+              <Link
+                to="/ranking"
+                className={getLinkClassName("/ranking")}
+              >
+                ランキング
               </Link>
             </div>
           </div>

--- a/search/frontend/src/components/RankingForm.tsx
+++ b/search/frontend/src/components/RankingForm.tsx
@@ -1,0 +1,140 @@
+import { useForm, Controller } from "react-hook-form";
+import { useEffect } from "react";
+
+export interface RankingFormData {
+  id: string;
+  main_text: string;
+  name_and_trip: string;
+  since: string;
+  until: string;
+}
+
+export function RankingForm({
+  onSubmit,
+  defaultValues,
+  isSearching,
+}: {
+  onSubmit: (data: RankingFormData) => void;
+  defaultValues: RankingFormData;
+  isSearching: boolean;
+}) {
+  const { control, handleSubmit, reset } = useForm<RankingFormData>({
+    defaultValues: defaultValues,
+  });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="bg-white shadow-md rounded-lg p-6 mb-8"
+    >
+      <div className="mb-4">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          ID:
+          <Controller
+            name="id"
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                type="text"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              />
+            )}
+          />
+        </label>
+      </div>
+      <div className="mb-4">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          名前:
+          <Controller
+            name="name_and_trip"
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                type="text"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              />
+            )}
+          />
+        </label>
+      </div>
+      <div className="mb-4">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          本文:
+          <Controller
+            name="main_text"
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                type="text"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              />
+            )}
+          />
+        </label>
+      </div>
+      <div className="mb-4">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          開始:
+          <Controller
+            name="since"
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                type="date"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              />
+            )}
+          />
+        </label>
+      </div>
+      <div className="mb-4">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          終了:
+          <Controller
+            name="until"
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                type="date"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              />
+            )}
+          />
+        </label>
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isSearching}
+          className={`
+            flex items-center px-4 py-2 rounded
+            ${
+              isSearching
+                ? "bg-gray-400 cursor-not-allowed"
+                : "bg-blue-500 hover:bg-blue-700"
+            }
+            text-white font-bold focus:outline-none focus:shadow-outline
+          `}
+        >
+          {isSearching ? (
+            <>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+              検索中...
+            </>
+          ) : (
+            "検索"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/search/frontend/src/pages/Oekaki.tsx
+++ b/search/frontend/src/pages/Oekaki.tsx
@@ -40,14 +40,15 @@ export default function Search() {
     setIsSearching(true);
     setCount(null);
     setFormData(data);
-    setSearchParams({
-      id: data.id,
-      main_text: data.main_text,
-      name_and_trip: data.name_and_trip,
-      ascending: data.ascending.toString(),
-      since: data.since,
-      until: data.until,
-    });
+    // 空文字列の値を除外してURLパラメータを設定
+    const params: Record<string, string> = {};
+    if (data.id) params.id = data.id;
+    if (data.main_text) params.main_text = data.main_text;
+    if (data.name_and_trip) params.name_and_trip = data.name_and_trip;
+    params.ascending = data.ascending.toString(); // ascendingは常に設定
+    if (data.since) params.since = data.since;
+    if (data.until) params.until = data.until;
+    setSearchParams(params);
 
     if (data.ascending) {
       cursor.current = 0;

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Form } from '../components/Form';
+import { Header } from '../components/Header';
+import { getRanking } from '../utils/Fetch';
+import { RankingItem, RankingResponse, FormData } from '../types';
+
+export default function Ranking() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [ranking, setRanking] = useState<RankingItem[]>([]);
+  const [totalUniqueIds, setTotalUniqueIds] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormData] = useState<FormData>(() => ({
+    id: searchParams.get("id") || "",
+    main_text: searchParams.get("main_text") || "",
+    name_and_trip: searchParams.get("name_and_trip") || "",
+    ascending: false,
+    since: searchParams.get("since") || "",
+    until: searchParams.get("until") || "",
+  }));
+  const formRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetchRanking();
+  }, []);
+
+  const fetchRanking = async (params: Partial<FormData> = {}) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await getRanking({
+        id: params.id || formData.id || undefined,
+        main_text: params.main_text || formData.main_text || undefined,
+        name_and_trip: params.name_and_trip || formData.name_and_trip || undefined,
+        since: params.since || formData.since || undefined,
+        until: params.until || formData.until || undefined,
+      });
+      setRanking(response.ranking);
+      setTotalUniqueIds(response.total_unique_ids);
+    } catch (error) {
+      console.error('Failed to fetch ranking:', error);
+      setError('ランキングの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFormSubmit = async (data: FormData) => {
+    setFormData(data);
+    setSearchParams({
+      id: data.id,
+      main_text: data.main_text,
+      name_and_trip: data.name_and_trip,
+      since: data.since,
+      until: data.until,
+    });
+    await fetchRanking(data);
+  };
+
+  const handleIdClick = (id: string) => {
+    // IDをクリックしたら検索ページに遷移
+    window.location.href = `/?id=${encodeURIComponent(id)}`;
+  };
+
+  const formatDateTime = (dateTimeStr: string) => {
+    try {
+      const date = new Date(dateTimeStr);
+      return date.toLocaleString('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+    } catch {
+      return dateTimeStr;
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Header />
+      
+      <div ref={formRef} className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">IDランキング</h1>
+        <Form onSubmit={handleFormSubmit} defaultValues={formData} isSearching={loading} />
+      </div>
+      
+      {totalUniqueIds > 0 && (
+        <div className="mb-4 text-gray-700">
+          <p>ユニークID数: {totalUniqueIds.toLocaleString()}</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-center py-8">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+          <p className="mt-2">読み込み中...</p>
+        </div>
+      ) : ranking.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border border-gray-300 shadow-sm">
+            <thead>
+              <tr className="bg-gray-100 border-b border-gray-300">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                  順位
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                  ID
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-700 uppercase tracking-wider">
+                  投稿数
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                  最新投稿
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                  最初の投稿
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {ranking.map((item) => (
+                <tr key={item.rank} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                    {item.rank}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <button
+                      onClick={() => handleIdClick(item.id)}
+                      className="text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium"
+                    >
+                      {item.id}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 text-right">
+                    {item.post_count.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <div className="text-sm">
+                      <div className="text-gray-900">No.{item.latest_post_no}</div>
+                      <div className="text-gray-500 text-xs">
+                        {formatDateTime(item.latest_post_datetime)}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <div className="text-sm">
+                      <div className="text-gray-900">No.{item.first_post_no}</div>
+                      <div className="text-gray-500 text-xs">
+                        {formatDateTime(item.first_post_datetime)}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : !loading && (
+        <div className="text-center py-8 text-gray-500">
+          ランキングデータがありません
+        </div>
+      )}
+    </div>
+  );
+}

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -49,13 +49,14 @@ export default function Ranking() {
 
   const handleFormSubmit = async (data: RankingFormData) => {
     setFormData(data);
-    setSearchParams({
-      id: data.id,
-      main_text: data.main_text,
-      name_and_trip: data.name_and_trip,
-      since: data.since,
-      until: data.until,
-    });
+    // 空文字列の値を除外してURLパラメータを設定
+    const params: Record<string, string> = {};
+    if (data.id) params.id = data.id;
+    if (data.main_text) params.main_text = data.main_text;
+    if (data.name_and_trip) params.name_and_trip = data.name_and_trip;
+    if (data.since) params.since = data.since;
+    if (data.until) params.until = data.until;
+    setSearchParams(params);
     await fetchRanking(data);
   };
 

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -81,96 +81,102 @@ export default function Ranking() {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <>
       <Header />
-      
-      <div ref={formRef} className="mb-8">
-        <h1 className="text-2xl font-bold mb-4">IDランキング</h1>
-        <RankingForm onSubmit={handleFormSubmit} defaultValues={formData} isSearching={loading} />
+      <div className="min-h-screen bg-gray-100 py-8 px-4">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center">
+            IDランキング
+          </h1>
+          
+          <div ref={formRef} className="mb-8">
+            <RankingForm onSubmit={handleFormSubmit} defaultValues={formData} isSearching={loading} />
+          </div>
+          
+          {(totalUniqueIds > 0 || totalResCount > 0) && (
+            <div className="mb-4 text-gray-700">
+              <p>検索結果: {totalResCount.toLocaleString()}件 (書き込みID数: {totalUniqueIds.toLocaleString()}件)</p>
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="text-center py-8">
+              <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+              <p className="mt-2">読み込み中...</p>
+            </div>
+          ) : ranking.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full bg-white border border-gray-300 shadow-sm">
+                <thead>
+                  <tr className="bg-gray-100 border-b border-gray-300">
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                      順位
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                      ID
+                    </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-700 uppercase tracking-wider">
+                      投稿数
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                      最新投稿
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                      最初の投稿
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {ranking.map((item) => (
+                    <tr key={item.rank} className="hover:bg-gray-50 transition-colors">
+                      <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                        {item.rank}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <button
+                          onClick={() => handleIdClick(item.id)}
+                          className="text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium"
+                        >
+                          {item.id}
+                        </button>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 text-right">
+                        {item.post_count.toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <div className="text-sm">
+                          <div className="text-gray-900">No.{item.latest_post_no}</div>
+                          <div className="text-gray-500 text-xs">
+                            {formatDateTime(item.latest_post_datetime)}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <div className="text-sm">
+                          <div className="text-gray-900">No.{item.first_post_no}</div>
+                          <div className="text-gray-500 text-xs">
+                            {formatDateTime(item.first_post_datetime)}
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : !loading && (
+            <div className="text-center py-8 text-gray-500">
+              ランキングデータがありません
+            </div>
+          )}
+        </div>
       </div>
-      
-      {(totalUniqueIds > 0 || totalResCount > 0) && (
-        <div className="mb-4 text-gray-700">
-          <p>検索結果: {totalResCount.toLocaleString()}件 (書き込みID数: {totalUniqueIds.toLocaleString()}件)</p>
-        </div>
-      )}
-
-      {error && (
-        <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
-          {error}
-        </div>
-      )}
-
-      {loading ? (
-        <div className="text-center py-8">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-          <p className="mt-2">読み込み中...</p>
-        </div>
-      ) : ranking.length > 0 ? (
-        <div className="overflow-x-auto">
-          <table className="min-w-full bg-white border border-gray-300 shadow-sm">
-            <thead>
-              <tr className="bg-gray-100 border-b border-gray-300">
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
-                  順位
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
-                  ID
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-700 uppercase tracking-wider">
-                  投稿数
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
-                  最新投稿
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
-                  最初の投稿
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {ranking.map((item) => (
-                <tr key={item.rank} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
-                    {item.rank}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    <button
-                      onClick={() => handleIdClick(item.id)}
-                      className="text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium"
-                    >
-                      {item.id}
-                    </button>
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 text-right">
-                    {item.post_count.toLocaleString()}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    <div className="text-sm">
-                      <div className="text-gray-900">No.{item.latest_post_no}</div>
-                      <div className="text-gray-500 text-xs">
-                        {formatDateTime(item.latest_post_datetime)}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    <div className="text-sm">
-                      <div className="text-gray-900">No.{item.first_post_no}</div>
-                      <div className="text-gray-500 text-xs">
-                        {formatDateTime(item.first_post_datetime)}
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : !loading && (
-        <div className="text-center py-8 text-gray-500">
-          ランキングデータがありません
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -1,21 +1,21 @@
 import { useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Form } from '../components/Form';
+import { RankingForm, RankingFormData } from '../components/RankingForm';
 import { Header } from '../components/Header';
 import { getRanking } from '../utils/Fetch';
-import { RankingItem, FormData } from '../types';
+import { RankingItem } from '../types';
 
 export default function Ranking() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [ranking, setRanking] = useState<RankingItem[]>([]);
   const [totalUniqueIds, setTotalUniqueIds] = useState(0);
+  const [totalResCount, setTotalResCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [formData, setFormData] = useState<FormData>(() => ({
+  const [formData, setFormData] = useState<RankingFormData>(() => ({
     id: searchParams.get("id") || "",
     main_text: searchParams.get("main_text") || "",
     name_and_trip: searchParams.get("name_and_trip") || "",
-    ascending: false,
     since: searchParams.get("since") || "",
     until: searchParams.get("until") || "",
   }));
@@ -25,7 +25,7 @@ export default function Ranking() {
     fetchRanking();
   }, []);
 
-  const fetchRanking = async (params: Partial<FormData> = {}) => {
+  const fetchRanking = async (params: Partial<RankingFormData> = {}) => {
     setLoading(true);
     setError(null);
     try {
@@ -38,6 +38,7 @@ export default function Ranking() {
       });
       setRanking(response.ranking);
       setTotalUniqueIds(response.total_unique_ids);
+      setTotalResCount(response.total_res_count);
     } catch (error) {
       console.error('Failed to fetch ranking:', error);
       setError('ランキングの取得に失敗しました');
@@ -46,7 +47,7 @@ export default function Ranking() {
     }
   };
 
-  const handleFormSubmit = async (data: FormData) => {
+  const handleFormSubmit = async (data: RankingFormData) => {
     setFormData(data);
     setSearchParams({
       id: data.id,
@@ -85,12 +86,12 @@ export default function Ranking() {
       
       <div ref={formRef} className="mb-8">
         <h1 className="text-2xl font-bold mb-4">IDランキング</h1>
-        <Form onSubmit={handleFormSubmit} defaultValues={formData} isSearching={loading} />
+        <RankingForm onSubmit={handleFormSubmit} defaultValues={formData} isSearching={loading} />
       </div>
       
-      {totalUniqueIds > 0 && (
+      {(totalUniqueIds > 0 || totalResCount > 0) && (
         <div className="mb-4 text-gray-700">
-          <p>ユニークID数: {totalUniqueIds.toLocaleString()}</p>
+          <p>検索結果: {totalResCount.toLocaleString()}件 (書き込みID数: {totalUniqueIds.toLocaleString()}件)</p>
         </div>
       )}
 

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -22,7 +22,7 @@ export default function Ranking() {
   const formRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetchRanking();
+    fetchRanking(formData);
   }, []);
 
   const fetchRanking = async (params: Partial<RankingFormData> = {}) => {
@@ -30,11 +30,11 @@ export default function Ranking() {
     setError(null);
     try {
       const response = await getRanking({
-        id: params.id || formData.id || undefined,
-        main_text: params.main_text || formData.main_text || undefined,
-        name_and_trip: params.name_and_trip || formData.name_and_trip || undefined,
-        since: params.since || formData.since || undefined,
-        until: params.until || formData.until || undefined,
+        id: params.id || undefined,
+        main_text: params.main_text || undefined,
+        name_and_trip: params.name_and_trip || undefined,
+        since: params.since || undefined,
+        until: params.until || undefined,
       });
       setRanking(response.ranking);
       setTotalUniqueIds(response.total_unique_ids);

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Form } from '../components/Form';
 import { Header } from '../components/Header';
 import { getRanking } from '../utils/Fetch';
-import { RankingItem, RankingResponse, FormData } from '../types';
+import { RankingItem, FormData } from '../types';
 
 export default function Ranking() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/search/frontend/src/pages/Search.tsx
+++ b/search/frontend/src/pages/Search.tsx
@@ -40,14 +40,15 @@ export default function Search() {
     setIsSearching(true);
     setCount(null);
     setFormData(data);
-    setSearchParams({
-      id: data.id,
-      main_text: data.main_text,
-      name_and_trip: data.name_and_trip,
-      ascending: data.ascending.toString(),
-      since: data.since,
-      until: data.until,
-    });
+    // 空文字列の値を除外してURLパラメータを設定
+    const params: Record<string, string> = {};
+    if (data.id) params.id = data.id;
+    if (data.main_text) params.main_text = data.main_text;
+    if (data.name_and_trip) params.name_and_trip = data.name_and_trip;
+    params.ascending = data.ascending.toString(); // ascendingは常に設定
+    if (data.since) params.since = data.since;
+    if (data.until) params.until = data.until;
+    setSearchParams(params);
 
     if (data.ascending) {
       cursor.current = 0;

--- a/search/frontend/src/types.ts
+++ b/search/frontend/src/types.ts
@@ -38,6 +38,7 @@ export interface RankingItem {
 export interface RankingResponse {
   ranking: RankingItem[];
   total_unique_ids: number;
+  total_res_count: number;
   search_conditions: {
     id?: string;
     main_text?: string;

--- a/search/frontend/src/types.ts
+++ b/search/frontend/src/types.ts
@@ -24,3 +24,37 @@ export interface FormData {
   since: string;
   until: string;
 }
+
+export interface RankingItem {
+  rank: number;
+  id: string;
+  post_count: number;
+  latest_post_no: number;
+  latest_post_datetime: string;
+  first_post_no: number;
+  first_post_datetime: string;
+}
+
+export interface RankingResponse {
+  ranking: RankingItem[];
+  total_unique_ids: number;
+  search_conditions: {
+    id?: string;
+    main_text?: string;
+    name_and_trip?: string;
+    oekaki?: boolean;
+    since?: string;
+    until?: string;
+  };
+}
+
+export interface RankingParams {
+  id?: string;
+  main_text?: string;
+  name_and_trip?: string;
+  oekaki?: boolean;
+  since?: string;
+  until?: string;
+  ranking_type?: 'post_count' | 'recent_activity';
+  min_posts?: number;
+}

--- a/search/frontend/src/utils/Fetch.ts
+++ b/search/frontend/src/utils/Fetch.ts
@@ -1,4 +1,4 @@
-import { FormData } from "../types";
+import { FormData, RankingParams, RankingResponse } from "../types";
 
 export const BASE_URL = import.meta.env.VITE_BASE_URL;
 
@@ -24,4 +24,25 @@ export async function fetchData(
     method: "GET",
   });
   return await response.json();
+}
+
+export async function getRanking(params: RankingParams = {}): Promise<RankingResponse> {
+  const queryParams = new URLSearchParams();
+  
+  if (params.id) queryParams.append('id', params.id);
+  if (params.main_text) queryParams.append('main_text', params.main_text);
+  if (params.name_and_trip) queryParams.append('name_and_trip', params.name_and_trip);
+  if (params.oekaki !== undefined) queryParams.append('oekaki', params.oekaki.toString());
+  if (params.since) queryParams.append('since', params.since);
+  if (params.until) queryParams.append('until', params.until);
+  if (params.ranking_type) queryParams.append('ranking_type', params.ranking_type);
+  if (params.min_posts !== undefined) queryParams.append('min_posts', params.min_posts.toString());
+  
+  const response = await fetch(`${BASE_URL}/api/v1/ranking?${queryParams}`);
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ranking: ${response.statusText}`);
+  }
+  
+  return response.json();
 }


### PR DESCRIPTION
## 概要
検索システムにIDごとの投稿数ランキング機能を追加しました。

## 変更内容

### バックエンド
- データベースの`id`カラムにインデックスを追加してパフォーマンスを向上
- Kernel層にランキングモデルとリポジトリインターフェースを実装
- Adapter層に動的SQLクエリビルダーを含むランキングリポジトリを実装
- `GET /api/v1/ranking`エンドポイントを追加（フィルタリング対応）
- Registry層を依存性注入に対応するよう更新

### フロントエンド
- ソート可能なテーブル表示を持つランキングページを追加
- 絞り込みランキング用の検索フォーム統合を実装
- アクティブ状態表示付きのナビゲーションタブを追加
- ランキングエンドポイント用のAPIクライアント関数を作成
- ランキングデータ用のTypeScript型定義を追加

## 機能
- 投稿数順に全ユーザーIDを表示（制限なし）
- 検索条件（ID、テキスト、名前、日付範囲）でランキングを絞り込み
- IDをクリックしてそのユーザーの検索結果に遷移
- モバイル対応のレスポンシブテーブルデザイン
- リアルタイムのローディング状態とエラーハンドリング

## APIサポート
- 複数のランキングタイプ（post_count、recent_activity）
- 最小投稿数フィルタリング
- 完全な検索パラメータ互換性

## テスト計画
- [ ] バックエンドAPIの動作確認（curl等）
- [ ] フロントエンドの表示確認
- [ ] 検索条件での絞り込み動作確認
- [ ] IDクリックによる遷移確認
- [ ] レスポンシブデザインの確認

## 注意事項
- SQLXのオフラインモードのため、実際の動作確認にはデータベース接続が必要です
- マイグレーションファイルが含まれているため、デプロイ時にマイグレーションの実行が必要です

🤖 Generated with [Claude Code](https://claude.ai/code)