### PR TITLE
Fix toLocaleString error on undefined values in ranking page

### DIFF
--- a/search/frontend/src/components/Count.tsx
+++ b/search/frontend/src/components/Count.tsx
@@ -7,8 +7,8 @@ export function Count({ count }: { count: CountJson | null }) {
 
   return (
     <div className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline">
-      検索結果: {count.total_res_count.toLocaleString()}件 (書き込みID数:{" "}
-      {count.unique_id_count.toLocaleString()}件)
+      検索結果: {count.total_res_count?.toLocaleString() || '0'}件 (書き込みID数:{" "}
+      {count.unique_id_count?.toLocaleString() || '0'}件)
     </div>
   );
 }

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -36,9 +36,9 @@ export default function Ranking() {
         since: params.since || undefined,
         until: params.until || undefined,
       });
-      setRanking(response.ranking);
-      setTotalUniqueIds(response.total_unique_ids);
-      setTotalResCount(response.total_res_count);
+      setRanking(response.ranking || []);
+      setTotalUniqueIds(response.total_unique_ids || 0);
+      setTotalResCount(response.total_res_count || 0);
     } catch (error) {
       console.error('Failed to fetch ranking:', error);
       setError('ランキングの取得に失敗しました');
@@ -96,7 +96,7 @@ export default function Ranking() {
           
           {(totalUniqueIds > 0 || totalResCount > 0) && (
             <div className="mb-4 text-gray-700">
-              <p>検索結果: {totalResCount.toLocaleString()}件 (書き込みID数: {totalUniqueIds.toLocaleString()}件)</p>
+              <p>検索結果: {totalResCount?.toLocaleString() || '0'}件 (書き込みID数: {totalUniqueIds?.toLocaleString() || '0'}件)</p>
             </div>
           )}
 
@@ -148,7 +148,7 @@ export default function Ranking() {
                         </button>
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 text-right">
-                        {item.post_count.toLocaleString()}
+                        {item.post_count?.toLocaleString() || '0'}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         <div className="text-sm">


### PR DESCRIPTION
## Summary
- Fixed runtime error "Cannot read properties of undefined (reading 'toLocaleString')" in the ranking page
- Added null/undefined checks before calling toLocaleString() method
- Ensured graceful handling when API response fields are missing

## Changes
- **Ranking.tsx**: Added fallback values when setting state from API response and optional chaining for display values
- **Count.tsx**: Added optional chaining and fallback '0' for count display values

## Test plan
- [x] Navigate to /ranking page
- [x] Verify no runtime errors occur when loading the page
- [x] Confirm that counts display as '0' when API returns undefined values
- [x] Test with various search parameters to ensure stability

🤖 Generated with [Claude Code](https://claude.ai/code)