### PR TITLE
Fix Cloudflare Pages TypeScript dependency mismatch

### DIFF
--- a/search/frontend/package.json
+++ b/search/frontend/package.json
@@ -28,7 +28,7 @@
     "globals": "^15.11.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
-    "typescript": "~5.9.0",
+    "typescript": "~5.6.2",
     "typescript-eslint": "^8.10.0",
     "vite": "^5.4.9"
   }


### PR DESCRIPTION
## Summary
- revert the search frontend TypeScript constraint from `~5.9.0` to `~5.6.2`
- restore consistency with the committed `package-lock.json`
- keep TypeScript within the supported range of the locked `typescript-eslint` packages

## Root cause
PR #63 updated only `package.json`. Cloudflare Pages uses `npm ci`, which rejected the mismatch with `package-lock.json`; TypeScript 5.9 was also outside the locked `typescript-eslint@8.34.1` peer range.

## Verification
- `npm ci`
- `npm run build`