### PR TITLE
add MCP server docs page and infinite scroll viewer to frontend

### DIFF
--- a/search/frontend/src/App.tsx
+++ b/search/frontend/src/App.tsx
@@ -8,12 +8,14 @@ import Mcp from "./pages/Mcp";
 import Oekaki from "./pages/Oekaki";
 import Ranking from "./pages/Ranking";
 import Search from "./pages/Search";
+import Viewer from "./pages/Viewer";
 
 export default function App() {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route>
         <Route path="/" element={<Search />} />
+        <Route path="/viewer" element={<Viewer />} />
         <Route path="/oekaki" element={<Oekaki />} />
         <Route path="/ranking" element={<Ranking />} />
         <Route path="/mcp" element={<Mcp />} />

--- a/search/frontend/src/App.tsx
+++ b/search/frontend/src/App.tsx
@@ -4,9 +4,10 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
 } from "react-router-dom";
-import Search from "./pages/Search";
+import Mcp from "./pages/Mcp";
 import Oekaki from "./pages/Oekaki";
 import Ranking from "./pages/Ranking";
+import Search from "./pages/Search";
 
 export default function App() {
   const router = createBrowserRouter(
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/" element={<Search />} />
         <Route path="/oekaki" element={<Oekaki />} />
         <Route path="/ranking" element={<Ranking />} />
+        <Route path="/mcp" element={<Mcp />} />
       </Route>,
     ),
   );

--- a/search/frontend/src/components/Header.tsx
+++ b/search/frontend/src/components/Header.tsx
@@ -45,6 +45,9 @@ export function Header() {
               <Link to="/" className={getLinkClassName("/")}>
                 掲示板検索
               </Link>
+              <Link to="/viewer" className={getLinkClassName("/viewer")}>
+                ビュワー
+              </Link>
               <Link to="/oekaki" className={getLinkClassName("/oekaki")}>
                 お絵かきをまとめる機械
               </Link>

--- a/search/frontend/src/components/Header.tsx
+++ b/search/frontend/src/components/Header.tsx
@@ -51,6 +51,9 @@ export function Header() {
               <Link to="/ranking" className={getLinkClassName("/ranking")}>
                 IDランキング
               </Link>
+              <Link to="/mcp" className={getLinkClassName("/mcp")}>
+                MCPサーバー
+              </Link>
             </div>
           </div>
           <div className="flex items-center">

--- a/search/frontend/src/components/Res.tsx
+++ b/search/frontend/src/components/Res.tsx
@@ -1,0 +1,65 @@
+import type { ResJson } from "../types";
+import { getImageUrl } from "../utils/Fetch";
+import { NoLink } from "./NoLink";
+
+export function Res({
+  res,
+  onIdClick,
+  highlighted = false,
+}: {
+  res: ResJson;
+  onIdClick: (id: string) => void;
+  highlighted?: boolean;
+}) {
+  return (
+    <li
+      className={`py-4 ${
+        highlighted ? "-mx-2 rounded bg-yellow-50 px-2 dark:bg-yellow-900/20" : ""
+      }`}
+    >
+      <div className="text-sm text-gray-600 mb-2 dark:text-gray-400">
+        <NoLink no={res.no} /> <div className="inline">{res.name_and_trip}</div>{" "}
+        <div className="inline">{res.datetime_text}</div>{" "}
+        <div className="inline">
+          ID:{" "}
+          <button
+            type="button"
+            onClick={() => onIdClick(res.id)}
+            className="hover:underline text-blue-600 cursor-pointer dark:text-blue-400"
+          >
+            {res.id}
+          </button>
+        </div>
+      </div>
+      <div
+        className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-blue-400"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
+        dangerouslySetInnerHTML={{ __html: res.main_text_html }}
+      />
+      {res.oekaki_id && <Oekaki res={res} />}
+    </li>
+  );
+}
+
+function Oekaki({ res }: { res: ResJson }) {
+  if (!res.oekaki_id) {
+    return null;
+  }
+
+  const imageUrl = getImageUrl(res.oekaki_id);
+  return (
+    <div className="mt-2 prose prose-sm dark:prose-invert">
+      <img src={imageUrl} alt={res.oekaki_title} className="max-w-full" />
+      {res.oekaki_title && (
+        <div className="text-gray-800 dark:text-gray-100">
+          タイトル: {res.oekaki_title}
+        </div>
+      )}
+      {res.original_oekaki_res_no && (
+        <div className="text-gray-800 dark:text-gray-100">
+          <NoLink no={res.original_oekaki_res_no} /> この絵を基にしています！
+        </div>
+      )}
+    </div>
+  );
+}

--- a/search/frontend/src/pages/Mcp.tsx
+++ b/search/frontend/src/pages/Mcp.tsx
@@ -1,0 +1,135 @@
+import { Header } from "../components/Header";
+
+const MCP_ENDPOINT = "https://bbs-mcp.toof.jp/mcp";
+
+const TOOLS = [
+  {
+    name: "search_posts",
+    description:
+      "本文・投稿者ID・名前/トリップ・期間などの条件でレスを検索する (カーソルページング対応)",
+  },
+  {
+    name: "count_posts",
+    description: "検索条件に一致するレス総数とユニーク投稿者ID数を返す",
+  },
+  {
+    name: "get_ranking",
+    description: "投稿者IDランキングを返す (投稿数順 / 直近活動順)",
+  },
+  {
+    name: "get_oekaki_image",
+    description: "oekaki_idを指定してお絵かき画像を取得する",
+  },
+];
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="overflow-x-auto rounded bg-gray-100 p-4 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export default function Mcp() {
+  return (
+    <>
+      <Header />
+      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
+            MCPサーバー
+          </h1>
+
+          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+            <p className="text-gray-700 leading-relaxed dark:text-gray-300">
+              この掲示板検索は{" "}
+              <a
+                href="https://modelcontextprotocol.io/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline dark:text-blue-400"
+              >
+                MCP (Model Context Protocol)
+              </a>{" "}
+              サーバーとしても公開されています。Claude
+              などのAIアシスタントに接続すると、AIが掲示板のレス検索・集計・お絵かき画像の取得を行えるようになります。
+            </p>
+          </div>
+
+          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+            <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
+              エンドポイント
+            </h2>
+            <CodeBlock>{MCP_ENDPOINT}</CodeBlock>
+            <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+              Streamable HTTP形式・認証なしで利用できます。
+            </p>
+          </div>
+
+          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+            <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
+              利用できるツール
+            </h2>
+            <ul className="space-y-3">
+              {TOOLS.map((tool) => (
+                <li key={tool.name}>
+                  <code className="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+                    {tool.name}
+                  </code>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {tool.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+            <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
+              接続方法
+            </h2>
+
+            <h3 className="font-semibold text-gray-800 mb-2 dark:text-gray-200">
+              Claude Code
+            </h3>
+            <CodeBlock>
+              {`claude mcp add --transport http bbs-search ${MCP_ENDPOINT}`}
+            </CodeBlock>
+
+            <h3 className="font-semibold text-gray-800 mt-4 mb-2 dark:text-gray-200">
+              claude.ai (カスタムコネクタ)
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              「設定」→「コネクタ」→「カスタムコネクタを追加」でURLに上記エンドポイントを入力してください。
+            </p>
+
+            <h3 className="font-semibold text-gray-800 mt-4 mb-2 dark:text-gray-200">
+              その他のMCPクライアント
+            </h3>
+            <CodeBlock>
+              {`{
+  "mcpServers": {
+    "bbs-search": {
+      "type": "http",
+      "url": "${MCP_ENDPOINT}"
+    }
+  }
+}`}
+            </CodeBlock>
+          </div>
+
+          <div className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900">
+            <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
+              使用例
+            </h2>
+            <ul className="list-disc list-inside space-y-1 text-sm text-gray-600 dark:text-gray-400">
+              <li>「昨日いちばん投稿数が多かったIDを調べて」</li>
+              <li>「『ラーメン』を含むレスを検索して要約して」</li>
+              <li>「最近投稿されたお絵かきを見せて」</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/search/frontend/src/pages/Search.tsx
+++ b/search/frontend/src/pages/Search.tsx
@@ -3,11 +3,11 @@ import InfiniteScroll from "react-infinite-scroller";
 import { useSearchParams } from "react-router-dom";
 
 import type { ResJson, CountJson, FormData } from "../types";
-import { fetchData, getImageUrl } from "../utils/Fetch";
+import { fetchData } from "../utils/Fetch";
 import { Form } from "../components/Form";
 import { Count } from "../components/Count";
-import { NoLink } from "../components/NoLink";
 import { Header } from "../components/Header";
+import { Res } from "../components/Res";
 
 export default function Search() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -156,59 +156,6 @@ function Result({
           ))}
         </ul>
       </InfiniteScroll>
-    </div>
-  );
-}
-
-function Res({
-  res,
-  onIdClick,
-}: { res: ResJson; onIdClick: (id: string) => void }) {
-  return (
-    <li className="py-4">
-      <div className="text-sm text-gray-600 mb-2 dark:text-gray-400">
-        <NoLink no={res.no} /> <div className="inline">{res.name_and_trip}</div>{" "}
-        <div className="inline">{res.datetime_text}</div>{" "}
-        <div className="inline">
-          ID:{" "}
-          <button
-            type="button"
-            onClick={() => onIdClick(res.id)}
-            className="hover:underline text-blue-600 cursor-pointer dark:text-blue-400"
-          >
-            {res.id}
-          </button>
-        </div>
-      </div>
-      <div
-        className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-blue-400"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
-        dangerouslySetInnerHTML={{ __html: res.main_text_html }}
-      />
-      {res.oekaki_id && <Oekaki res={res} />}
-    </li>
-  );
-}
-
-function Oekaki({ res }: { res: ResJson }) {
-  if (!res.oekaki_id) {
-    return null;
-  }
-
-  const imageUrl = getImageUrl(res.oekaki_id);
-  return (
-    <div className="mt-2 prose prose-sm dark:prose-invert">
-      <img src={imageUrl} alt={res.oekaki_title} className="max-w-full" />
-      {res.oekaki_title && (
-        <div className="text-gray-800 dark:text-gray-100">
-          タイトル: {res.oekaki_title}
-        </div>
-      )}
-      {res.original_oekaki_res_no && (
-        <div className="text-gray-800 dark:text-gray-100">
-          <NoLink no={res.original_oekaki_res_no} /> この絵を基にしています！
-        </div>
-      )}
     </div>
   );
 }

--- a/search/frontend/src/pages/Viewer.tsx
+++ b/search/frontend/src/pages/Viewer.tsx
@@ -1,0 +1,459 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import InfiniteScroll from "react-infinite-scroller";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { Header } from "../components/Header";
+import { Res } from "../components/Res";
+import type { FormData, ResJson } from "../types";
+import { fetchData } from "../utils/Fetch";
+
+const RESULT_LIMIT = 100;
+const MAX_CURSOR = 2147483647;
+
+function viewerForm(ascending: boolean, since = ""): FormData {
+  return {
+    id: "",
+    main_text: "",
+    name_and_trip: "",
+    ascending,
+    since,
+    until: "",
+  };
+}
+
+// NaiveDateTime は "YYYY-MM-DDTHH:MM:SS" で届くので、
+// datetime-local の値 "YYYY-MM-DDTHH:MM" と文字列比較できる
+function resDatetime(res: ResJson): string {
+  return String(res.datetime);
+}
+
+export default function Viewer() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [result, setResult] = useState<ResJson[]>([]);
+  const [hasMoreDown, setHasMoreDown] = useState(false);
+  const [hasMoreUp, setHasMoreUp] = useState(false);
+  const [isJumping, setIsJumping] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [anchorNo, setAnchorNo] = useState<number | null>(null);
+  const [noInput, setNoInput] = useState(searchParams.get("no") || "");
+  const [datetimeInput, setDatetimeInput] = useState(
+    searchParams.get("datetime") || "",
+  );
+
+  const topCursor = useRef(0);
+  const bottomCursor = useRef(0);
+  const hasMoreUpRef = useRef(false);
+  const loadingUp = useRef(false);
+  const loadingDown = useRef(false);
+  const pendingScrollHeight = useRef<number | null>(null);
+  const pendingScrollBottom = useRef(false);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+
+  const setHasMoreUpBoth = (value: boolean) => {
+    hasMoreUpRef.current = value;
+    setHasMoreUp(value);
+  };
+
+  const loadUp = useCallback(async () => {
+    if (loadingUp.current || !hasMoreUpRef.current) {
+      return;
+    }
+    loadingUp.current = true;
+    try {
+      const response: ResJson[] = await fetchData(
+        "search",
+        viewerForm(false),
+        topCursor.current,
+      );
+      if (response.length === 0) {
+        hasMoreUpRef.current = false;
+        setHasMoreUp(false);
+        return;
+      }
+      topCursor.current = response[response.length - 1].no;
+      if (response.length < RESULT_LIMIT) {
+        hasMoreUpRef.current = false;
+        setHasMoreUp(false);
+      }
+      // プリペンドで表示位置がずれないよう、描画後に scrollTop を補正する
+      pendingScrollHeight.current =
+        document.scrollingElement?.scrollHeight ?? null;
+      setResult((prev) => [...response.slice().reverse(), ...prev]);
+    } finally {
+      loadingUp.current = false;
+    }
+  }, []);
+
+  const loadDown = async () => {
+    if (loadingDown.current) {
+      return;
+    }
+    loadingDown.current = true;
+    try {
+      const response: ResJson[] = await fetchData(
+        "search",
+        viewerForm(true),
+        bottomCursor.current,
+      );
+      if (response.length < RESULT_LIMIT) {
+        setHasMoreDown(false);
+      }
+      if (response.length === 0) {
+        return;
+      }
+      bottomCursor.current = response[response.length - 1].no;
+      setResult((prev) => [...prev, ...response]);
+    } finally {
+      loadingDown.current = false;
+    }
+  };
+
+  const showLatest = async () => {
+    const response: ResJson[] = await fetchData(
+      "search",
+      viewerForm(false),
+      MAX_CURSOR,
+    );
+    const posts = response.slice().reverse();
+    setAnchorNo(null);
+    if (posts.length === 0) {
+      setResult([]);
+      setHasMoreDown(false);
+      setHasMoreUpBoth(false);
+      return;
+    }
+    topCursor.current = posts[0].no;
+    bottomCursor.current = posts[posts.length - 1].no;
+    setResult(posts);
+    setHasMoreDown(false);
+    setHasMoreUpBoth(response.length === RESULT_LIMIT);
+    pendingScrollBottom.current = true;
+  };
+
+  const jumpToNoCore = async (no: number) => {
+    const down: ResJson[] = await fetchData(
+      "search",
+      viewerForm(true),
+      no - 1,
+    );
+    if (down.length === 0) {
+      setNotice("指定のレス番号以降の投稿がないため、最新のレスを表示します。");
+      await showLatest();
+      return;
+    }
+    topCursor.current = down[0].no;
+    bottomCursor.current = down[down.length - 1].no;
+    setResult(down);
+    setHasMoreDown(down.length === RESULT_LIMIT);
+    setHasMoreUpBoth(down[0].no > 1);
+    setAnchorNo(down[0].no);
+    window.scrollTo(0, 0);
+  };
+
+  // レス番号は時系列順なので、日付で絞った後にレス番号の二分探索で
+  // 指定日時以降の最初のレスを見つける
+  const findNoByDatetime = async (
+    datetime: string,
+  ): Promise<number | "latest"> => {
+    const since = datetime.slice(0, 10);
+    const first: ResJson[] = await fetchData(
+      "search",
+      viewerForm(true, since),
+      0,
+    );
+    if (first.length === 0) {
+      return "latest";
+    }
+    const hit = first.find((res) => resDatetime(res) >= datetime);
+    if (hit) {
+      return hit.no;
+    }
+    if (first.length < RESULT_LIMIT) {
+      return "latest";
+    }
+    const latestPage: ResJson[] = await fetchData(
+      "search",
+      viewerForm(false),
+      MAX_CURSOR,
+    );
+    if (latestPage.length === 0 || resDatetime(latestPage[0]) < datetime) {
+      return "latest";
+    }
+    let lo = first[first.length - 1].no + 1;
+    let hi = latestPage[0].no;
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const page: ResJson[] = await fetchData(
+        "search",
+        viewerForm(true),
+        mid - 1,
+      );
+      if (page.length === 0 || resDatetime(page[0]) >= datetime) {
+        hi = mid;
+        continue;
+      }
+      const found = page.find((res) => resDatetime(res) >= datetime);
+      if (found) {
+        return found.no;
+      }
+      lo = page[page.length - 1].no + 1;
+    }
+    return hi;
+  };
+
+  const jumpToNo = async (no: number) => {
+    setIsJumping(true);
+    setNotice(null);
+    try {
+      await jumpToNoCore(no);
+    } finally {
+      setIsJumping(false);
+    }
+  };
+
+  const jumpToDatetime = async (datetime: string) => {
+    setIsJumping(true);
+    setNotice(null);
+    try {
+      const no = await findNoByDatetime(datetime);
+      if (no === "latest") {
+        setNotice("指定日時以降の投稿がないため、最新のレスを表示します。");
+        await showLatest();
+      } else {
+        await jumpToNoCore(no);
+      }
+    } finally {
+      setIsJumping(false);
+    }
+  };
+
+  const jumpToLatest = async () => {
+    setIsJumping(true);
+    setNotice(null);
+    try {
+      await showLatest();
+    } finally {
+      setIsJumping(false);
+    }
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: URL query params are loaded once on page entry.
+  useEffect(() => {
+    const noParam = searchParams.get("no");
+    const datetimeParam = searchParams.get("datetime");
+    if (noParam && /^\d+$/.test(noParam)) {
+      jumpToNo(Number.parseInt(noParam, 10));
+    } else if (datetimeParam) {
+      jumpToDatetime(datetimeParam);
+    } else {
+      jumpToLatest();
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll compensation must run after each result change.
+  useLayoutEffect(() => {
+    const el = document.scrollingElement;
+    if (!el) {
+      return;
+    }
+    if (pendingScrollHeight.current !== null) {
+      el.scrollTop += el.scrollHeight - pendingScrollHeight.current;
+      pendingScrollHeight.current = null;
+    } else if (pendingScrollBottom.current) {
+      el.scrollTop = el.scrollHeight;
+      pendingScrollBottom.current = false;
+    }
+  }, [result]);
+
+  useEffect(() => {
+    const sentinel = topSentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          loadUp();
+        }
+      },
+      { rootMargin: "300px 0px 0px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadUp]);
+
+  const handleNoSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const no = Number.parseInt(noInput, 10);
+    if (!Number.isFinite(no) || no < 1) {
+      return;
+    }
+    setDatetimeInput("");
+    setSearchParams({ no: no.toString() });
+    jumpToNo(no);
+  };
+
+  const handleDatetimeSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!datetimeInput) {
+      return;
+    }
+    setNoInput("");
+    setSearchParams({ datetime: datetimeInput });
+    jumpToDatetime(datetimeInput);
+  };
+
+  const handleLatestClick = () => {
+    setNoInput("");
+    setDatetimeInput("");
+    setSearchParams({});
+    jumpToLatest();
+  };
+
+  const handleIdClick = (id: string) => {
+    navigate(`/?id=${encodeURIComponent(id)}`);
+  };
+
+  const spinner = (
+    <div className="flex justify-center py-4 text-gray-600">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 dark:border-gray-400" />
+    </div>
+  );
+
+  const inputClassName =
+    "rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
+  const buttonClassName =
+    "rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50";
+
+  return (
+    <>
+      <Header />
+      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
+            掲示板ビュワー
+          </h1>
+          <div className="bg-white shadow-md rounded-lg p-4 mb-4 dark:bg-gray-900">
+            <div className="flex flex-wrap items-center gap-4">
+              <form onSubmit={handleNoSubmit} className="flex items-center gap-2">
+                <label
+                  htmlFor="jump-no"
+                  className="text-sm text-gray-700 dark:text-gray-300"
+                >
+                  レス番号
+                </label>
+                <input
+                  id="jump-no"
+                  type="number"
+                  min="1"
+                  value={noInput}
+                  onChange={(event) => setNoInput(event.target.value)}
+                  className={`${inputClassName} w-32`}
+                  placeholder="1"
+                />
+                <button
+                  type="submit"
+                  disabled={isJumping}
+                  className={buttonClassName}
+                >
+                  ジャンプ
+                </button>
+              </form>
+              <form
+                onSubmit={handleDatetimeSubmit}
+                className="flex items-center gap-2"
+              >
+                <label
+                  htmlFor="jump-datetime"
+                  className="text-sm text-gray-700 dark:text-gray-300"
+                >
+                  日時
+                </label>
+                <input
+                  id="jump-datetime"
+                  type="datetime-local"
+                  value={datetimeInput}
+                  onChange={(event) => setDatetimeInput(event.target.value)}
+                  className={inputClassName}
+                />
+                <button
+                  type="submit"
+                  disabled={isJumping}
+                  className={buttonClassName}
+                >
+                  ジャンプ
+                </button>
+              </form>
+              <button
+                type="button"
+                onClick={handleLatestClick}
+                disabled={isJumping}
+                className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              >
+                最新へ
+              </button>
+            </div>
+          </div>
+          {notice && (
+            <div className="mb-4 rounded-lg bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+              {notice}
+            </div>
+          )}
+          {isJumping ? (
+            spinner
+          ) : (
+            result.length > 0 && (
+              <div
+                className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900"
+                style={{ overflowAnchor: "none" }}
+              >
+                <div ref={topSentinelRef} />
+                {hasMoreUp ? (
+                  spinner
+                ) : (
+                  <div className="pb-2 text-center text-sm text-gray-500 dark:text-gray-400">
+                    これより前のレスはありません
+                  </div>
+                )}
+                <InfiniteScroll
+                  loadMore={loadDown}
+                  hasMore={hasMoreDown}
+                  loader={spinner}
+                >
+                  <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+                    {result.map((res) => (
+                      <Res
+                        key={res.no}
+                        res={res}
+                        onIdClick={handleIdClick}
+                        highlighted={res.no === anchorNo}
+                      />
+                    ))}
+                  </ul>
+                </InfiniteScroll>
+                {!hasMoreDown && (
+                  <div className="pt-4 text-center">
+                    <button
+                      type="button"
+                      onClick={() => loadDown()}
+                      className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      新着を確認
+                    </button>
+                  </div>
+                )}
+              </div>
+            )
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/search/frontend/src/pages/Viewer.tsx
+++ b/search/frontend/src/pages/Viewer.tsx
@@ -54,7 +54,7 @@ export default function Viewer() {
   const loadingDown = useRef(false);
   const pendingScrollHeight = useRef<number | null>(null);
   const pendingScrollBottom = useRef(false);
-  const topSentinelRef = useRef<HTMLDivElement>(null);
+  const topObserver = useRef<IntersectionObserver | null>(null);
 
   const setHasMoreUpBoth = (value: boolean) => {
     hasMoreUpRef.current = value;
@@ -272,22 +272,28 @@ export default function Viewer() {
     }
   }, [result]);
 
-  useEffect(() => {
-    const sentinel = topSentinelRef.current;
-    if (!sentinel) {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          loadUp();
-        }
-      },
-      { rootMargin: "300px 0px 0px 0px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadUp]);
+  // センチネルはジャンプ完了後に初めて DOM に現れるため、
+  // useEffect ではなく callback ref で Observer を設置する
+  const topSentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      topObserver.current?.disconnect();
+      topObserver.current = null;
+      if (!node) {
+        return;
+      }
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            loadUp();
+          }
+        },
+        { rootMargin: "300px 0px 0px 0px" },
+      );
+      observer.observe(node);
+      topObserver.current = observer;
+    },
+    [loadUp],
+  );
 
   const handleNoSubmit = (event: React.FormEvent) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary

フロントエンドに2つのページを追加します。

### MCPサーバードキュメントページ (`/mcp`)
- MCPサーバーの利用方法を説明するページを追加

### 無限スクロールビュワー (`/viewer`)
- 全レスを時系列に読める双方向無限スクロールビュワー
  - 下方向: react-infinite-scroller / 上方向: IntersectionObserver + スクロール位置補正
- レス番号ジャンプ(既存 search API の cursor を利用)
- 日時ジャンプ(レス番号が時系列順であることを利用し、`since` で日付まで絞った後レス番号の二分探索で該当時刻の最初のレスを特定。バックエンド変更なし)
- `?no=` / `?datetime=` の URL パラメータで共有可能
- 最新へジャンプ・新着確認ボタン
- レス表示コンポーネントを `components/Res.tsx` に抽出し Search ページと共通化

## Test plan

- [x] `npm run build` / `npm run lint` が通ることを確認
- [x] 日時ジャンプの二分探索ロジックを本番 API に対して検証(境界の直前レス < 指定日時 <= 該当レス、3リクエスト程度)
- [ ] `/viewer` で上下スクロール・各ジャンプの動作をブラウザで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)