### PR TITLE
redesign frontend UI and fix mobile header layout

### DIFF
--- a/search/frontend/index.html
+++ b/search/frontend/index.html
@@ -21,7 +21,7 @@
       })();
     </script>
   </head>
-  <body class="bg-gray-100 dark:bg-gray-950">
+  <body class="bg-gray-50 dark:bg-gray-950">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/search/frontend/src/components/Count.tsx
+++ b/search/frontend/src/components/Count.tsx
@@ -6,9 +6,16 @@ export function Count({ count }: { count: CountJson | null }) {
   }
 
   return (
-    <div className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-blue-400">
-      検索結果: {count.total_res_count?.toLocaleString() || "0"}件
-      (書き込みID数: {count.unique_id_count?.toLocaleString() || "0"}件)
+    <div className="mb-2 text-sm text-gray-600 dark:text-gray-300">
+      検索結果:{" "}
+      <span className="font-semibold text-gray-900 dark:text-gray-50">
+        {count.total_res_count?.toLocaleString() || "0"}
+      </span>
+      件 (書き込みID数:{" "}
+      <span className="font-semibold text-gray-900 dark:text-gray-50">
+        {count.unique_id_count?.toLocaleString() || "0"}
+      </span>
+      件)
     </div>
   );
 }

--- a/search/frontend/src/components/Form.tsx
+++ b/search/frontend/src/components/Form.tsx
@@ -21,36 +21,24 @@ export function Form({
   }, [defaultValues, reset]);
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="bg-white shadow-md rounded-lg p-6 mb-8 dark:bg-gray-900"
-    >
-      <div className="mb-4">
-        <label
-          htmlFor="search-id"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          ID:
+    <form onSubmit={handleSubmit(onSubmit)} className="card mb-8 p-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="search-id" className="form-label">
+            ID
+          </label>
           <Controller
             name="id"
             control={control}
             render={({ field }) => (
-              <input
-                {...field}
-                id="search-id"
-                type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-              />
+              <input {...field} id="search-id" type="text" className="input" />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="search-name-and-trip"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          名前:
+        </div>
+        <div>
+          <label htmlFor="search-name-and-trip" className="form-label">
+            名前
+          </label>
           <Controller
             name="name_and_trip"
             control={control}
@@ -59,18 +47,15 @@ export function Form({
                 {...field}
                 id="search-name-and-trip"
                 type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="search-main-text"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          本文:
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="search-main-text" className="form-label">
+            本文
+          </label>
           <Controller
             name="main_text"
             control={control}
@@ -79,18 +64,15 @@ export function Form({
                 {...field}
                 id="search-main-text"
                 type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="search-since"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          開始:
+        </div>
+        <div>
+          <label htmlFor="search-since" className="form-label">
+            開始
+          </label>
           <Controller
             name="since"
             control={control}
@@ -99,18 +81,15 @@ export function Form({
                 {...field}
                 id="search-since"
                 type="date"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="search-until"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          終了:
+        </div>
+        <div>
+          <label htmlFor="search-until" className="form-label">
+            終了
+          </label>
           <Controller
             name="until"
             control={control}
@@ -119,41 +98,39 @@ export function Form({
                 {...field}
                 id="search-until"
                 type="date"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
+        </div>
       </div>
-      <div className="mb-4 flex justify-between items-center">
+      <div className="mt-6 flex flex-wrap items-end justify-between gap-4">
         <fieldset>
-          <legend className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200">
-            順番:
-          </legend>
+          <legend className="form-label">順番</legend>
           <Controller
             name="ascending"
             control={control}
             render={({ field: { onChange, value } }) => (
-              <div className="flex items-center space-x-6">
-                <label className="inline-flex items-center cursor-pointer">
+              <div className="flex items-center gap-6">
+                <label className="inline-flex cursor-pointer items-center">
                   <input
                     type="radio"
                     checked={value === true}
                     onChange={() => onChange(true)}
-                    className="w-4 h-4 text-blue-600 border-gray-300 focus:ring-2 focus:ring-blue-500"
+                    className="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
                   />
-                  <span className="ml-2 text-gray-700 dark:text-gray-200">
+                  <span className="ml-2 text-sm text-gray-700 dark:text-gray-200">
                     古い順
                   </span>
                 </label>
-                <label className="inline-flex items-center cursor-pointer">
+                <label className="inline-flex cursor-pointer items-center">
                   <input
                     type="radio"
                     checked={value === false}
                     onChange={() => onChange(false)}
-                    className="w-4 h-4 text-blue-600 border-gray-300 focus:ring-2 focus:ring-blue-500"
+                    className="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
                   />
-                  <span className="ml-2 text-gray-700 dark:text-gray-200">
+                  <span className="ml-2 text-sm text-gray-700 dark:text-gray-200">
                     新しい順
                   </span>
                 </label>
@@ -161,22 +138,10 @@ export function Form({
             )}
           />
         </fieldset>
-        <button
-          type="submit"
-          disabled={isSearching}
-          className={`
-            flex items-center px-4 py-2 rounded
-            ${
-              isSearching
-                ? "bg-gray-400 cursor-not-allowed"
-                : "bg-blue-500 hover:bg-blue-700"
-            }
-            text-white font-bold focus:outline-none focus:shadow-outline
-          `}
-        >
+        <button type="submit" disabled={isSearching} className="btn-primary">
           {isSearching ? (
             <>
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+              <div className="spinner h-4 w-4 border-white/40 border-t-white" />
               検索中...
             </>
           ) : (

--- a/search/frontend/src/components/Header.tsx
+++ b/search/frontend/src/components/Header.tsx
@@ -3,9 +3,23 @@ import { Link, useLocation } from "react-router-dom";
 import { THEME_STORAGE_KEY, applyTheme, getStoredTheme } from "../theme";
 import type { ThemeSetting } from "../theme";
 
+const NAV_ITEMS = [
+  { path: "/", label: "掲示板検索" },
+  { path: "/viewer", label: "ビュワー" },
+  { path: "/oekaki", label: "お絵かきをまとめる機械" },
+  { path: "/ranking", label: "IDランキング" },
+  { path: "/mcp", label: "MCPサーバー" },
+];
+
 export function Header() {
   const location = useLocation();
   const [theme, setTheme] = useState<ThemeSetting>(() => getStoredTheme());
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: close the mobile menu on navigation.
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     applyTheme(theme);
@@ -30,34 +44,86 @@ export function Header() {
 
   const getLinkClassName = (path: string) => {
     const baseClass =
-      "inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium";
+      "whitespace-nowrap rounded-lg px-3 py-2 text-sm transition";
     return isActive(path)
-      ? `${baseClass} border-blue-500 text-gray-900 dark:text-gray-100`
-      : `${baseClass} border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-300 dark:hover:text-white dark:hover:border-gray-600`;
+      ? `${baseClass} bg-indigo-50 font-semibold text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300`
+      : `${baseClass} font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white`;
+  };
+
+  const getMobileLinkClassName = (path: string) => {
+    const baseClass = "block rounded-lg px-3 py-2 text-base transition";
+    return isActive(path)
+      ? `${baseClass} bg-indigo-50 font-semibold text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300`
+      : `${baseClass} font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white`;
   };
 
   return (
-    <header className="bg-white shadow-md dark:bg-gray-900 dark:shadow-gray-950/50">
-      <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16">
-          <div className="flex">
-            <div className="flex space-x-8">
-              <Link to="/" className={getLinkClassName("/")}>
-                掲示板検索
+    <header className="sticky top-0 z-40 border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
+      <nav className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between gap-4">
+          <div className="flex items-center gap-2 lg:hidden">
+            <button
+              type="button"
+              onClick={() => setIsMenuOpen((open) => !open)}
+              aria-controls="mobile-menu"
+              aria-expanded={isMenuOpen}
+              className="inline-flex items-center justify-center rounded-lg p-2 text-gray-600 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+            >
+              <span className="sr-only">メニューを開く</span>
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                {isMenuOpen ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                )}
+              </svg>
+            </button>
+            <Link
+              to="/"
+              className="flex items-center gap-2 font-bold text-gray-900 dark:text-gray-50"
+            >
+              <svg
+                className="h-6 w-6 text-indigo-600 dark:text-indigo-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                />
+              </svg>
+              掲示板検索
+            </Link>
+          </div>
+          <div className="hidden items-center gap-1 lg:flex">
+            {NAV_ITEMS.map((item) => (
+              <Link
+                key={item.path}
+                to={item.path}
+                className={getLinkClassName(item.path)}
+              >
+                {item.label}
               </Link>
-              <Link to="/viewer" className={getLinkClassName("/viewer")}>
-                ビュワー
-              </Link>
-              <Link to="/oekaki" className={getLinkClassName("/oekaki")}>
-                お絵かきをまとめる機械
-              </Link>
-              <Link to="/ranking" className={getLinkClassName("/ranking")}>
-                IDランキング
-              </Link>
-              <Link to="/mcp" className={getLinkClassName("/mcp")}>
-                MCPサーバー
-              </Link>
-            </div>
+            ))}
           </div>
           <div className="flex items-center">
             <label className="sr-only" htmlFor="theme-menu">
@@ -67,7 +133,7 @@ export function Header() {
               id="theme-menu"
               value={theme}
               onChange={(event) => setTheme(event.target.value as ThemeSetting)}
-              className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              className="rounded-lg border border-gray-300 bg-white px-2.5 py-1.5 text-sm text-gray-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             >
               <option value="light">☀️ ライト</option>
               <option value="dark">🌙 ダーク</option>
@@ -75,6 +141,19 @@ export function Header() {
             </select>
           </div>
         </div>
+        {isMenuOpen && (
+          <div id="mobile-menu" className="space-y-1 pb-4 pt-1 lg:hidden">
+            {NAV_ITEMS.map((item) => (
+              <Link
+                key={item.path}
+                to={item.path}
+                className={getMobileLinkClassName(item.path)}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        )}
       </nav>
     </header>
   );

--- a/search/frontend/src/components/NoLink.tsx
+++ b/search/frontend/src/components/NoLink.tsx
@@ -2,12 +2,7 @@ export function NoLink({ no }: { no: number }) {
   const pageNo = Math.floor((no - 1) / 30) * 30 + 1;
   const url = `https://dic.nicovideo.jp/b/c/ch2598430/${pageNo}-#${no}`;
   return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noreferrer"
-      className="text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
-    >
+    <a href={url} target="_blank" rel="noreferrer" className="text-link">
       {no}
     </a>
   );

--- a/search/frontend/src/components/RankingForm.tsx
+++ b/search/frontend/src/components/RankingForm.tsx
@@ -27,36 +27,24 @@ export function RankingForm({
   }, [defaultValues, reset]);
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="bg-white shadow-md rounded-lg p-6 mb-8 dark:bg-gray-900"
-    >
-      <div className="mb-4">
-        <label
-          htmlFor="ranking-id"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          ID:
+    <form onSubmit={handleSubmit(onSubmit)} className="card p-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="ranking-id" className="form-label">
+            ID
+          </label>
           <Controller
             name="id"
             control={control}
             render={({ field }) => (
-              <input
-                {...field}
-                id="ranking-id"
-                type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-              />
+              <input {...field} id="ranking-id" type="text" className="input" />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="ranking-name-and-trip"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          名前:
+        </div>
+        <div>
+          <label htmlFor="ranking-name-and-trip" className="form-label">
+            名前
+          </label>
           <Controller
             name="name_and_trip"
             control={control}
@@ -65,18 +53,15 @@ export function RankingForm({
                 {...field}
                 id="ranking-name-and-trip"
                 type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="ranking-main-text"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          本文:
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="ranking-main-text" className="form-label">
+            本文
+          </label>
           <Controller
             name="main_text"
             control={control}
@@ -85,18 +70,15 @@ export function RankingForm({
                 {...field}
                 id="ranking-main-text"
                 type="text"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="ranking-since"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          開始:
+        </div>
+        <div>
+          <label htmlFor="ranking-since" className="form-label">
+            開始
+          </label>
           <Controller
             name="since"
             control={control}
@@ -105,18 +87,15 @@ export function RankingForm({
                 {...field}
                 id="ranking-since"
                 type="date"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
-      </div>
-      <div className="mb-4">
-        <label
-          htmlFor="ranking-until"
-          className="block text-gray-700 text-sm font-bold mb-2 dark:text-gray-200"
-        >
-          終了:
+        </div>
+        <div>
+          <label htmlFor="ranking-until" className="form-label">
+            終了
+          </label>
           <Controller
             name="until"
             control={control}
@@ -125,29 +104,17 @@ export function RankingForm({
                 {...field}
                 id="ranking-until"
                 type="date"
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                className="input"
               />
             )}
           />
-        </label>
+        </div>
       </div>
-      <div className="flex justify-end">
-        <button
-          type="submit"
-          disabled={isSearching}
-          className={`
-            flex items-center px-4 py-2 rounded
-            ${
-              isSearching
-                ? "bg-gray-400 cursor-not-allowed"
-                : "bg-blue-500 hover:bg-blue-700"
-            }
-            text-white font-bold focus:outline-none focus:shadow-outline
-          `}
-        >
+      <div className="mt-6 flex justify-end">
+        <button type="submit" disabled={isSearching} className="btn-primary">
           {isSearching ? (
             <>
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+              <div className="spinner h-4 w-4 border-white/40 border-t-white" />
               検索中...
             </>
           ) : (

--- a/search/frontend/src/components/Res.tsx
+++ b/search/frontend/src/components/Res.tsx
@@ -14,25 +14,27 @@ export function Res({
   return (
     <li
       className={`py-4 ${
-        highlighted ? "-mx-2 rounded bg-yellow-50 px-2 dark:bg-yellow-900/20" : ""
+        highlighted
+          ? "-mx-2 rounded-lg bg-yellow-50 px-2 dark:bg-yellow-900/20"
+          : ""
       }`}
     >
-      <div className="text-sm text-gray-600 mb-2 dark:text-gray-400">
-        <NoLink no={res.no} /> <div className="inline">{res.name_and_trip}</div>{" "}
-        <div className="inline">{res.datetime_text}</div>{" "}
-        <div className="inline">
-          ID:{" "}
-          <button
-            type="button"
-            onClick={() => onIdClick(res.id)}
-            className="hover:underline text-blue-600 cursor-pointer dark:text-blue-400"
-          >
-            {res.id}
-          </button>
-        </div>
+      <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+        <NoLink no={res.no} />
+        <span className="font-medium text-gray-700 dark:text-gray-300">
+          {res.name_and_trip}
+        </span>
+        <span>{res.datetime_text}</span>
+        <button
+          type="button"
+          onClick={() => onIdClick(res.id)}
+          className="cursor-pointer rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 transition hover:bg-indigo-50 hover:text-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-300"
+        >
+          ID: {res.id}
+        </button>
       </div>
       <div
-        className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-blue-400"
+        className="prose prose-sm max-w-none text-gray-800 prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-indigo-400"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
         dangerouslySetInnerHTML={{ __html: res.main_text_html }}
       />
@@ -48,8 +50,12 @@ function Oekaki({ res }: { res: ResJson }) {
 
   const imageUrl = getImageUrl(res.oekaki_id);
   return (
-    <div className="mt-2 prose prose-sm dark:prose-invert">
-      <img src={imageUrl} alt={res.oekaki_title} className="max-w-full" />
+    <div className="prose prose-sm mt-2 dark:prose-invert">
+      <img
+        src={imageUrl}
+        alt={res.oekaki_title}
+        className="max-w-full rounded-lg border border-gray-200 dark:border-gray-800"
+      />
       {res.oekaki_title && (
         <div className="text-gray-800 dark:text-gray-100">
           タイトル: {res.oekaki_title}

--- a/search/frontend/src/components/Res.tsx
+++ b/search/frontend/src/components/Res.tsx
@@ -2,6 +2,56 @@ import type { ResJson } from "../types";
 import { getImageUrl } from "../utils/Fetch";
 import { NoLink } from "./NoLink";
 
+export function ResMeta({
+  res,
+  onIdClick,
+}: {
+  res: ResJson;
+  onIdClick: (id: string) => void;
+}) {
+  return (
+    <div className="mb-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+      <NoLink no={res.no} />
+      <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        {res.name_and_trip}
+      </span>
+      <span>{res.datetime_text}</span>
+      <button
+        type="button"
+        onClick={() => onIdClick(res.id)}
+        title="このIDの投稿を検索"
+        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-gray-200 bg-gray-50 px-1.5 py-0.5 font-mono text-[11px] text-gray-600 transition hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-indigo-700 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-300"
+      >
+        <svg
+          className="h-3 w-3"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-4.35-4.35M17 10.5a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"
+          />
+        </svg>
+        ID: {res.id}
+      </button>
+    </div>
+  );
+}
+
+export function ResBody({ res }: { res: ResJson }) {
+  return (
+    <div
+      className="prose prose-sm max-w-none leading-relaxed text-gray-900 prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-indigo-400"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
+      dangerouslySetInnerHTML={{ __html: res.main_text_html }}
+    />
+  );
+}
+
 export function Res({
   res,
   onIdClick,
@@ -19,25 +69,8 @@ export function Res({
           : ""
       }`}
     >
-      <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
-        <NoLink no={res.no} />
-        <span className="font-medium text-gray-700 dark:text-gray-300">
-          {res.name_and_trip}
-        </span>
-        <span>{res.datetime_text}</span>
-        <button
-          type="button"
-          onClick={() => onIdClick(res.id)}
-          className="cursor-pointer rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 transition hover:bg-indigo-50 hover:text-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-300"
-        >
-          ID: {res.id}
-        </button>
-      </div>
-      <div
-        className="prose prose-sm max-w-none text-gray-800 prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-indigo-400"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
-        dangerouslySetInnerHTML={{ __html: res.main_text_html }}
-      />
+      <ResMeta res={res} onIdClick={onIdClick} />
+      <ResBody res={res} />
       {res.oekaki_id && <Oekaki res={res} />}
     </li>
   );
@@ -54,7 +87,7 @@ function Oekaki({ res }: { res: ResJson }) {
       <img
         src={imageUrl}
         alt={res.oekaki_title}
-        className="max-w-full rounded-lg border border-gray-200 dark:border-gray-800"
+        className="max-w-full border border-gray-200 dark:border-gray-800"
       />
       {res.oekaki_title && (
         <div className="text-gray-800 dark:text-gray-100">

--- a/search/frontend/src/index.css
+++ b/search/frontend/src/index.css
@@ -1,3 +1,37 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .card {
+    @apply rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900;
+  }
+
+  .input {
+    @apply w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500;
+  }
+
+  .form-label {
+    @apply mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300;
+  }
+
+  .btn-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700;
+  }
+
+  .page-title {
+    @apply mb-6 text-center text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-3xl;
+  }
+
+  .text-link {
+    @apply text-indigo-600 transition hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300;
+  }
+
+  .spinner {
+    @apply animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600 dark:border-gray-700 dark:border-t-indigo-400;
+  }
+}

--- a/search/frontend/src/pages/Mcp.tsx
+++ b/search/frontend/src/pages/Mcp.tsx
@@ -24,7 +24,7 @@ const TOOLS = [
 
 function CodeBlock({ children }: { children: string }) {
   return (
-    <pre className="overflow-x-auto rounded bg-gray-100 p-4 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+    <pre className="overflow-x-auto rounded-lg bg-gray-100 p-4 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-100">
       <code>{children}</code>
     </pre>
   );
@@ -34,20 +34,18 @@ export default function Mcp() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+      <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-3xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
-            MCPサーバー
-          </h1>
+          <h1 className="page-title">MCPサーバー</h1>
 
-          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+          <div className="card mb-6 p-6">
             <p className="text-gray-700 leading-relaxed dark:text-gray-300">
               この掲示板検索は{" "}
               <a
                 href="https://modelcontextprotocol.io/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-link"
               >
                 MCP (Model Context Protocol)
               </a>{" "}
@@ -56,7 +54,7 @@ export default function Mcp() {
             </p>
           </div>
 
-          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+          <div className="card mb-6 p-6">
             <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
               エンドポイント
             </h2>
@@ -66,7 +64,7 @@ export default function Mcp() {
             </p>
           </div>
 
-          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+          <div className="card mb-6 p-6">
             <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
               利用できるツール
             </h2>
@@ -84,7 +82,7 @@ export default function Mcp() {
             </ul>
           </div>
 
-          <div className="bg-white shadow-md rounded-lg p-6 mb-6 dark:bg-gray-900">
+          <div className="card mb-6 p-6">
             <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
               接続方法
             </h2>
@@ -118,7 +116,7 @@ export default function Mcp() {
             </CodeBlock>
           </div>
 
-          <div className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900">
+          <div className="card p-6">
             <h2 className="text-lg font-bold text-gray-800 mb-3 dark:text-gray-100">
               使用例
             </h2>

--- a/search/frontend/src/pages/Oekaki.tsx
+++ b/search/frontend/src/pages/Oekaki.tsx
@@ -95,11 +95,9 @@ export default function Search() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+      <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
-            お絵描きをまとめる機械
-          </h1>
+          <h1 className="page-title">お絵描きをまとめる機械</h1>
           <div ref={formRef}>
             <Form
               onSubmit={handleFormSubmit}
@@ -136,13 +134,13 @@ function Result({
   onIdClick: (id: string) => void;
 }) {
   const loader = (
-    <div key="loader" className="flex justify-center py-4 text-gray-600">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600" />
+    <div key="loader" className="flex justify-center py-4">
+      <div className="spinner h-8 w-8" />
     </div>
   );
 
   return (
-    <div className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900">
+    <div className="card p-6">
       <Count count={count} />
       <InfiniteScroll
         loadMore={loadMore}
@@ -171,7 +169,7 @@ function OekakiCard({
   const imageUrl = getImageUrl(res.oekaki_id);
 
   return (
-    <div className="bg-white h-full border border-gray-200 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+    <div className="card h-full overflow-hidden transition hover:shadow-md">
       <div className="aspect-w-1 aspect-h-1 border-b border-gray-200 dark:border-gray-800">
         <img
           src={imageUrl}
@@ -179,21 +177,23 @@ function OekakiCard({
           className="w-full h-full object-cover"
         />
       </div>
-      <div className="text-sm text-gray-600 mb-2 p-4 dark:text-gray-400">
-        <NoLink no={res.no} /> <div className="inline">{res.name_and_trip}</div>{" "}
-        <div className="inline">{res.datetime_text}</div>{" "}
-        <div className="inline">
-          ID:{" "}
+      <div className="p-4 text-sm text-gray-500 dark:text-gray-400">
+        <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+          <NoLink no={res.no} />
+          <span className="font-medium text-gray-700 dark:text-gray-300">
+            {res.name_and_trip}
+          </span>
+          <span>{res.datetime_text}</span>
           <button
             type="button"
             onClick={() => onIdClick(res.id)}
-            className="hover:underline text-blue-600 cursor-pointer dark:text-blue-400"
+            className="cursor-pointer rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 transition hover:bg-indigo-50 hover:text-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-300"
           >
-            {res.id}
+            ID: {res.id}
           </button>
         </div>
         <div
-          className="text-gray-800 prose prose-sm max-w-none prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-blue-400"
+          className="text-gray-800 prose prose-sm max-w-none prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-indigo-400"
           // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
           dangerouslySetInnerHTML={{ __html: res.main_text_html }}
         />

--- a/search/frontend/src/pages/Oekaki.tsx
+++ b/search/frontend/src/pages/Oekaki.tsx
@@ -8,6 +8,7 @@ import { Form } from "../components/Form";
 import { Count } from "../components/Count";
 import { NoLink } from "../components/NoLink";
 import { Header } from "../components/Header";
+import { ResBody, ResMeta } from "../components/Res";
 
 export default function Search() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -169,7 +170,7 @@ function OekakiCard({
   const imageUrl = getImageUrl(res.oekaki_id);
 
   return (
-    <div className="card h-full overflow-hidden transition hover:shadow-md">
+    <div className="card h-full rounded-none transition hover:shadow-md">
       <div className="aspect-w-1 aspect-h-1 border-b border-gray-200 dark:border-gray-800">
         <img
           src={imageUrl}
@@ -177,33 +178,16 @@ function OekakiCard({
           className="w-full h-full object-cover"
         />
       </div>
-      <div className="p-4 text-sm text-gray-500 dark:text-gray-400">
-        <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1">
-          <NoLink no={res.no} />
-          <span className="font-medium text-gray-700 dark:text-gray-300">
-            {res.name_and_trip}
-          </span>
-          <span>{res.datetime_text}</span>
-          <button
-            type="button"
-            onClick={() => onIdClick(res.id)}
-            className="cursor-pointer rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 transition hover:bg-indigo-50 hover:text-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-300"
-          >
-            ID: {res.id}
-          </button>
-        </div>
-        <div
-          className="text-gray-800 prose prose-sm max-w-none prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline dark:prose-invert dark:text-gray-100 dark:prose-a:text-indigo-400"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: backend provides pre-rendered post HTML.
-          dangerouslySetInnerHTML={{ __html: res.main_text_html }}
-        />
+      <div className="p-4">
+        <ResMeta res={res} onIdClick={onIdClick} />
+        <ResBody res={res} />
         {res.oekaki_title && (
-          <div className="text-gray-800 dark:text-gray-100">
+          <div className="mt-1 text-sm text-gray-800 dark:text-gray-100">
             タイトル: {res.oekaki_title}
           </div>
         )}
         {res.original_oekaki_res_no && (
-          <div className="text-gray-800 dark:text-gray-100">
+          <div className="mt-1 text-sm text-gray-800 dark:text-gray-100">
             <NoLink no={res.original_oekaki_res_no} /> この絵を基にしています！
           </div>
         )}

--- a/search/frontend/src/pages/Ranking.tsx
+++ b/search/frontend/src/pages/Ranking.tsx
@@ -88,11 +88,9 @@ export default function Ranking() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+      <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
-            IDランキング
-          </h1>
+          <h1 className="page-title">IDランキング</h1>
 
           <div ref={formRef} className="mb-8">
             <RankingForm
@@ -103,30 +101,37 @@ export default function Ranking() {
           </div>
 
           {(totalUniqueIds > 0 || totalResCount > 0) && (
-            <div className="mb-4 text-gray-700 dark:text-gray-300">
+            <div className="mb-4 text-sm text-gray-600 dark:text-gray-300">
               <p>
-                検索結果: {totalResCount?.toLocaleString() || "0"}件
-                (書き込みID数: {totalUniqueIds?.toLocaleString() || "0"}件)
+                検索結果:{" "}
+                <span className="font-semibold text-gray-900 dark:text-gray-50">
+                  {totalResCount?.toLocaleString() || "0"}
+                </span>
+                件 (書き込みID数:{" "}
+                <span className="font-semibold text-gray-900 dark:text-gray-50">
+                  {totalUniqueIds?.toLocaleString() || "0"}
+                </span>
+                件)
               </p>
             </div>
           )}
 
           {error && (
-            <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+            <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
               {error}
             </div>
           )}
 
           {loading ? (
             <div className="text-center py-8 dark:text-gray-200">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-gray-200" />
+              <div className="spinner inline-block h-8 w-8" />
               <p className="mt-2">読み込み中...</p>
             </div>
           ) : ranking.length > 0 ? (
-            <div className="overflow-x-auto">
-              <table className="min-w-full bg-white border border-gray-300 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+            <div className="card overflow-x-auto">
+              <table className="min-w-full">
                 <thead>
-                  <tr className="bg-gray-100 border-b border-gray-300 dark:border-gray-800 dark:bg-gray-800">
+                  <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-800/50">
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider dark:text-gray-200">
                       順位
                     </th>
@@ -150,14 +155,22 @@ export default function Ranking() {
                       key={item.rank}
                       className="hover:bg-gray-50 transition-colors dark:hover:bg-gray-800"
                     >
-                      <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                        {item.rank}
+                      <td className="px-4 py-3 whitespace-nowrap text-sm">
+                        {item.rank <= 3 ? (
+                          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-50 text-xs font-bold text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300">
+                            {item.rank}
+                          </span>
+                        ) : (
+                          <span className="text-gray-900 dark:text-gray-100">
+                            {item.rank}
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         <button
                           type="button"
                           onClick={() => handleIdClick(item.id)}
-                          className="text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium dark:text-blue-400 dark:hover:text-blue-300"
+                          className="text-link font-mono text-sm font-medium"
                         >
                           {item.id}
                         </button>

--- a/search/frontend/src/pages/Search.tsx
+++ b/search/frontend/src/pages/Search.tsx
@@ -95,11 +95,9 @@ export default function Search() {
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+      <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
-            掲示板検索
-          </h1>
+          <h1 className="page-title">掲示板検索</h1>
           <div ref={formRef}>
             <Form
               onSubmit={handleFormSubmit}
@@ -136,13 +134,13 @@ function Result({
   onIdClick: (id: string) => void;
 }) {
   const loader = (
-    <div key="loader" className="flex justify-center py-4 text-gray-600">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600" />
+    <div key="loader" className="flex justify-center py-4">
+      <div className="spinner h-8 w-8" />
     </div>
   );
 
   return (
-    <div className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900">
+    <div className="card p-6">
       <Count count={count} />
       <InfiniteScroll
         loadMore={loadMore}

--- a/search/frontend/src/pages/Viewer.tsx
+++ b/search/frontend/src/pages/Viewer.tsx
@@ -138,11 +138,7 @@ export default function Viewer() {
   };
 
   const jumpToNoCore = async (no: number) => {
-    const down: ResJson[] = await fetchData(
-      "search",
-      viewerForm(true),
-      no - 1,
-    );
+    const down: ResJson[] = await fetchData("search", viewerForm(true), no - 1);
     if (down.length === 0) {
       setNotice("指定のレス番号以降の投稿がないため、最新のレスを表示します。");
       await showLatest();
@@ -328,27 +324,26 @@ export default function Viewer() {
   };
 
   const spinner = (
-    <div className="flex justify-center py-4 text-gray-600">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 dark:border-gray-400" />
+    <div className="flex justify-center py-4">
+      <div className="spinner h-8 w-8" />
     </div>
   );
 
-  const inputClassName =
-    "rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
-  const buttonClassName =
-    "rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50";
+  const inputClassName = "input";
+  const buttonClassName = "btn-primary";
 
   return (
     <>
       <Header />
-      <div className="min-h-screen bg-gray-100 py-8 px-4 dark:bg-gray-950">
+      <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mb-4 text-center dark:text-gray-100">
-            掲示板ビュワー
-          </h1>
-          <div className="bg-white shadow-md rounded-lg p-4 mb-4 dark:bg-gray-900">
+          <h1 className="page-title">掲示板ビュワー</h1>
+          <div className="card mb-4 p-4">
             <div className="flex flex-wrap items-center gap-4">
-              <form onSubmit={handleNoSubmit} className="flex items-center gap-2">
+              <form
+                onSubmit={handleNoSubmit}
+                className="flex items-center gap-2"
+              >
                 <label
                   htmlFor="jump-no"
                   className="text-sm text-gray-700 dark:text-gray-300"
@@ -387,7 +382,7 @@ export default function Viewer() {
                   type="datetime-local"
                   value={datetimeInput}
                   onChange={(event) => setDatetimeInput(event.target.value)}
-                  className={inputClassName}
+                  className={`${inputClassName} w-auto`}
                 />
                 <button
                   type="submit"
@@ -401,63 +396,58 @@ export default function Viewer() {
                 type="button"
                 onClick={handleLatestClick}
                 disabled={isJumping}
-                className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                className="btn-secondary"
               >
                 最新へ
               </button>
             </div>
           </div>
           {notice && (
-            <div className="mb-4 rounded-lg bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            <div className="mb-4 rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-900 dark:bg-yellow-900/30 dark:text-yellow-200">
               {notice}
             </div>
           )}
-          {isJumping ? (
-            spinner
-          ) : (
-            result.length > 0 && (
-              <div
-                className="bg-white shadow-md rounded-lg p-6 dark:bg-gray-900"
-                style={{ overflowAnchor: "none" }}
-              >
-                <div ref={topSentinelRef} />
-                {hasMoreUp ? (
-                  spinner
-                ) : (
-                  <div className="pb-2 text-center text-sm text-gray-500 dark:text-gray-400">
-                    これより前のレスはありません
-                  </div>
-                )}
-                <InfiniteScroll
-                  loadMore={loadDown}
-                  hasMore={hasMoreDown}
-                  loader={spinner}
-                >
-                  <ul className="divide-y divide-gray-200 dark:divide-gray-800">
-                    {result.map((res) => (
-                      <Res
-                        key={res.no}
-                        res={res}
-                        onIdClick={handleIdClick}
-                        highlighted={res.no === anchorNo}
-                      />
-                    ))}
-                  </ul>
-                </InfiniteScroll>
-                {!hasMoreDown && (
-                  <div className="pt-4 text-center">
-                    <button
-                      type="button"
-                      onClick={() => loadDown()}
-                      className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-                    >
-                      新着を確認
-                    </button>
-                  </div>
-                )}
-              </div>
-            )
-          )}
+          {isJumping
+            ? spinner
+            : result.length > 0 && (
+                <div className="card p-6" style={{ overflowAnchor: "none" }}>
+                  <div ref={topSentinelRef} />
+                  {hasMoreUp ? (
+                    spinner
+                  ) : (
+                    <div className="pb-2 text-center text-sm text-gray-500 dark:text-gray-400">
+                      これより前のレスはありません
+                    </div>
+                  )}
+                  <InfiniteScroll
+                    loadMore={loadDown}
+                    hasMore={hasMoreDown}
+                    loader={spinner}
+                  >
+                    <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+                      {result.map((res) => (
+                        <Res
+                          key={res.no}
+                          res={res}
+                          onIdClick={handleIdClick}
+                          highlighted={res.no === anchorNo}
+                        />
+                      ))}
+                    </ul>
+                  </InfiniteScroll>
+                  {!hasMoreDown && (
+                    <div className="pt-4 text-center">
+                      <button
+                        type="button"
+                        onClick={() => loadDown()}
+                        className="btn-secondary"
+                      >
+                        新着を確認
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
         </div>
       </div>
     </>

--- a/search/frontend/src/pages/Viewer.tsx
+++ b/search/frontend/src/pages/Viewer.tsx
@@ -338,15 +338,15 @@ export default function Viewer() {
       <div className="min-h-screen bg-gray-50 px-4 py-8 dark:bg-gray-950">
         <div className="max-w-4xl mx-auto">
           <h1 className="page-title">掲示板ビュワー</h1>
-          <div className="card mb-4 p-4">
-            <div className="flex flex-wrap items-center gap-4">
+          <div className="card sticky top-16 z-30 mb-4 bg-white/95 p-4 backdrop-blur dark:bg-gray-900/95">
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
               <form
                 onSubmit={handleNoSubmit}
                 className="flex items-center gap-2"
               >
                 <label
                   htmlFor="jump-no"
-                  className="text-sm text-gray-700 dark:text-gray-300"
+                  className="shrink-0 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
                 >
                   レス番号
                 </label>
@@ -356,13 +356,13 @@ export default function Viewer() {
                   min="1"
                   value={noInput}
                   onChange={(event) => setNoInput(event.target.value)}
-                  className={`${inputClassName} w-32`}
+                  className={`${inputClassName} min-w-0 flex-1 sm:w-32 sm:flex-none`}
                   placeholder="1"
                 />
                 <button
                   type="submit"
                   disabled={isJumping}
-                  className={buttonClassName}
+                  className={`${buttonClassName} shrink-0`}
                 >
                   ジャンプ
                 </button>
@@ -373,7 +373,7 @@ export default function Viewer() {
               >
                 <label
                   htmlFor="jump-datetime"
-                  className="text-sm text-gray-700 dark:text-gray-300"
+                  className="shrink-0 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
                 >
                   日時
                 </label>
@@ -382,12 +382,12 @@ export default function Viewer() {
                   type="datetime-local"
                   value={datetimeInput}
                   onChange={(event) => setDatetimeInput(event.target.value)}
-                  className={`${inputClassName} w-auto`}
+                  className={`${inputClassName} min-w-0 flex-1 sm:w-auto sm:flex-none`}
                 />
                 <button
                   type="submit"
                   disabled={isJumping}
-                  className={buttonClassName}
+                  className={`${buttonClassName} shrink-0`}
                 >
                   ジャンプ
                 </button>
@@ -396,7 +396,7 @@ export default function Viewer() {
                 type="button"
                 onClick={handleLatestClick}
                 disabled={isJumping}
-                className="btn-secondary"
+                className="btn-secondary self-start sm:self-auto"
               >
                 最新へ
               </button>

--- a/search/frontend/tailwind.config.js
+++ b/search/frontend/tailwind.config.js
@@ -8,7 +8,19 @@ export default {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: [
+          "Inter",
+          "Hiragino Sans",
+          "Noto Sans JP",
+          "Yu Gothic UI",
+          "Meiryo",
+          "system-ui",
+          "sans-serif",
+        ],
+      },
+    },
   },
   plugins: [
     typography,


### PR DESCRIPTION
## 概要
- モバイル幅でメニューバーが崩れていた問題を修正 (lg未満はハンバーガーメニューに切り替え)
- 全体のデザインを刷新

## 変更内容
### ヘッダー
- モバイル: ハンバーガーメニュー + ブランドロゴ表示、ナビはドロップダウンに格納
- sticky + backdrop-blur 化、ナビリンクをピル型に変更 (アクティブページはインディゴでハイライト)

### デザイン刷新
- `index.css` に共通コンポーネントクラス (`card` / `input` / `btn-primary` / `btn-secondary` / `form-label` / `page-title` / `text-link` / `spinner`) を定義し全ページで統一
- アクセントカラーを blue → indigo に変更、カードは角丸大きめ + 薄いボーダー + 控えめシャドウに
- 検索フォーム・ランキングフォームを2カラムグリッドに再構成
- ランキングテーブルをカード化、上位3位にバッジ表示
- レスのID表示をピル型ボタンに、日本語フォントスタックを追加

## 確認
- `npm run build` / `biome lint` パス
- モバイル (390px) / デスクトップ (1280px) でスクリーンショット確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)