### PR TITLE
add public Grafana dashboard for post volume

### DIFF
--- a/search/grafana/.env.example
+++ b/search/grafana/.env.example
@@ -1,0 +1,13 @@
+# Grafana 管理者パスワード(必須)
+GF_ADMIN_USER=admin
+GF_ADMIN_PASSWORD=CHANGE_ME
+
+# 公開 URL(リバースプロキシ経由で公開する場合はそのURL)
+GF_ROOT_URL=http://localhost:3000
+
+# Postgres 接続情報(setup/readonly-user.sql で作った読み取り専用ユーザーを使う)
+POSTGRES_HOST=localhost:5432
+POSTGRES_DB=postgres
+POSTGRES_USER=grafana_reader
+POSTGRES_PASSWORD=CHANGE_ME
+POSTGRES_SSLMODE=disable

--- a/search/grafana/README.md
+++ b/search/grafana/README.md
@@ -1,0 +1,76 @@
+# Grafana 投稿量ダッシュボード
+
+投稿量を公開するための Grafana 構成。匿名ユーザーは Viewer として閲覧でき、ダッシュボード上部のテキストボックスに ID を入力するとその ID の投稿量だけを表示する(空欄で全体)。
+
+## パネル
+
+- 期間内の投稿数 / ユニークID数
+- 投稿数の推移(時系列、ID で絞り込み可)
+- 投稿数ランキング Top 20
+- 時間帯別の投稿数
+
+## セットアップ
+
+1. 読み取り専用 DB ユーザーを作る(`setup/readonly-user.sql` のパスワードを変更してから):
+
+   ```bash
+   psql "$DATABASE_URL" -f setup/readonly-user.sql
+   ```
+
+   匿名公開する Grafana からはデータソースに対して任意の SELECT が実行され得るため、
+   crawler/backend 用のユーザーを使い回さず、必ずこの読み取り専用ユーザーを使うこと。
+
+2. `datetime` インデックスのマイグレーションを適用する(`search/migrations/20260719000000_add_datetime_index.sql`)。
+
+3. `.env` を用意して起動:
+
+   ```bash
+   cp .env.example .env
+   # .env を編集
+   docker compose up -d
+   ```
+
+4. `http://localhost:3000` を開くとログインなしでダッシュボードが表示される。
+   編集は `GF_ADMIN_USER` / `GF_ADMIN_PASSWORD` でログインして行う。
+
+公開する場合は Caddy / nginx などのリバースプロキシで HTTPS を終端し、`GF_ROOT_URL` にその URL を設定する。
+
+## Kubernetes へのデプロイ
+
+kustomize 構成(`kustomization.yaml` + `k8s/`)を用意してある。provisioning とダッシュボード JSON は ConfigMap として生成されるので、docker-compose 版と二重管理にならない。
+
+1. 読み取り専用 DB ユーザーとマイグレーションは docker-compose 版と同じく事前に適用する。
+
+2. `.env`(キーは `.env.example` と同じ)から Secret を作る:
+
+   ```bash
+   kubectl create namespace bbs-grafana
+   kubectl create secret generic bbs-grafana-env -n bbs-grafana --from-env-file=.env
+   ```
+
+3. デプロイ:
+
+   ```bash
+   kubectl apply -k .
+   ```
+
+   home-kubernetes-private の `apps/grafana/` にはこのディレクトリをリモート base として参照する
+   kustomization を置いてあるので、クラスタ側からは `kubectl apply -k apps/grafana` でもよい
+   (このリポジトリの main に push 済みであること)。
+
+Service は NodePort 30300 で公開している。Ingress やリバースプロキシで受ける場合は
+`k8s/service.yaml` を ClusterIP に変更し、`GF_ROOT_URL` を公開 URL に合わせる。
+Grafana の状態はすべてプロビジョニングで再現されるため `emptyDir` を使っており、PVC は不要。
+ダッシュボードを変更したときは JSON を更新して `kubectl apply -k` し直せば ConfigMap の
+ハッシュ付きの名前が変わり、自動でロールアウトされる。
+
+## タイムゾーンについて
+
+`res.datetime` は JST の壁時計時刻が timezone なしの `TIMESTAMP` として保存されている。
+このためダッシュボードのタイムゾーンを `utc` に固定してあり、表示はそのまま JST の時刻として読める。
+時間範囲の端(now 付近)は実時刻と最大 9 時間ずれるが、日次・月次の集計では実用上問題ない。
+
+## ダッシュボードの変更
+
+`dashboards/bbs-posts.json` がプロビジョニングで読み込まれる(UI からの保存は無効)。
+UI で編集して JSON をエクスポートし、このファイルを更新してコミットする。

--- a/search/grafana/dashboards/bbs-posts.json
+++ b/search/grafana/dashboards/bbs-posts.json
@@ -1,0 +1,199 @@
+{
+  "uid": "bbs-posts",
+  "title": "BBS 投稿量",
+  "description": "IDを指定して投稿量を確認できるダッシュボード。IDが空欄のときは全体の集計。",
+  "tags": ["bbs"],
+  "timezone": "utc",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "type": "textbox",
+        "name": "id",
+        "label": "ID (空欄で全体)",
+        "query": "",
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": []
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "期間内の投稿数",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 5 },
+      "datasource": { "type": "postgres", "uid": "bbs-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(*) AS \"投稿数\" FROM res WHERE $__timeFilter(datetime) AND (${id:sqlstring} = '' OR id = ${id:sqlstring})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "期間内のユニークID数",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 5 },
+      "datasource": { "type": "postgres", "uid": "bbs-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(DISTINCT id) AS \"ユニークID数\" FROM res WHERE $__timeFilter(datetime) AND id <> '' AND (${id:sqlstring} = '' OR id = ${id:sqlstring})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "投稿数の推移",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 10 },
+      "datasource": { "type": "postgres", "uid": "bbs-postgres" },
+      "interval": "1h",
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT $__timeGroup(datetime, $__interval, 0) AS time, count(*) AS \"投稿数\" FROM res WHERE $__timeFilter(datetime) AND (${id:sqlstring} = '' OR id = ${id:sqlstring}) GROUP BY 1 ORDER BY 1"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 1,
+            "pointSize": 4,
+            "showPoints": "never",
+            "axisPlacement": "auto",
+            "stacking": { "mode": "none" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      }
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "投稿数ランキング (Top 20)",
+      "gridPos": { "x": 0, "y": 15, "w": 12, "h": 11 },
+      "datasource": { "type": "postgres", "uid": "bbs-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT id AS \"ID\", count(*) AS \"投稿数\" FROM res WHERE $__timeFilter(datetime) AND id <> '' GROUP BY id ORDER BY count(*) DESC LIMIT 20"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "投稿数" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "gauge", "mode": "gradient" } },
+              { "id": "color", "value": { "mode": "continuous-BlPu" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": { "show": false }
+      }
+    },
+    {
+      "id": 5,
+      "type": "barchart",
+      "title": "時間帯別の投稿数",
+      "gridPos": { "x": 12, "y": 15, "w": 12, "h": 11 },
+      "datasource": { "type": "postgres", "uid": "bbs-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT extract(hour FROM datetime)::int AS \"時\", count(*) AS \"投稿数\" FROM res WHERE $__timeFilter(datetime) AND (${id:sqlstring} = '' OR id = ${id:sqlstring}) GROUP BY 1 ORDER BY 1"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 80, "lineWidth": 0 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "xField": "時",
+        "showValue": "never",
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      }
+    }
+  ]
+}

--- a/search/grafana/docker-compose.yml
+++ b/search/grafana/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  grafana:
+    image: grafana/grafana-oss:12.4.3
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # 管理者ログイン
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD is required}
+      # 匿名閲覧(公開用)。ViewerロールなのでダッシュボードのSQLは編集不可
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_ANONYMOUS_HIDE_VERSION: "true"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_SERVER_ROOT_URL: ${GF_ROOT_URL:-http://localhost:3000}
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/bbs-posts.json
+      # データソースのプロビジョニングで参照する
+      POSTGRES_HOST: ${POSTGRES_HOST:?POSTGRES_HOST is required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_SSLMODE: ${POSTGRES_SSLMODE:-disable}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./provisioning:/etc/grafana/provisioning:ro
+      - ./dashboards:/var/lib/grafana/dashboards:ro
+
+volumes:
+  grafana-data:

--- a/search/grafana/k8s/deployment.yaml
+++ b/search/grafana/k8s/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app: bbs-grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bbs-grafana
+  template:
+    metadata:
+      labels:
+        app: bbs-grafana
+    spec:
+      # control-plane ノードにもスケジューリング可（シングルノード用）
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+
+      securityContext:
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: grafana
+          image: grafana/grafana-oss:12.4.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+
+          # 接続情報・管理者パスワードは Secret から:
+          #   kubectl create secret generic bbs-grafana-env -n bbs-grafana --from-env-file=.env
+          # (.env のキーは docker-compose 用の .env.example と同じ)
+          envFrom:
+            - secretRef:
+                name: bbs-grafana-env
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: bbs-grafana-env
+                  key: GF_ADMIN_USER
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bbs-grafana-env
+                  key: GF_ADMIN_PASSWORD
+            - name: GF_SERVER_ROOT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bbs-grafana-env
+                  key: GF_ROOT_URL
+            # 匿名閲覧(公開用)。ViewerロールなのでダッシュボードのSQLは編集不可
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+            - name: GF_AUTH_ANONYMOUS_HIDE_VERSION
+              value: "true"
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_ANALYTICS_REPORTING_ENABLED
+              value: "false"
+            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+              value: /var/lib/grafana/dashboards/bbs-posts.json
+
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboard-providers
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+            # 状態はすべてプロビジョニングで再現できるので永続化しない。
+            # 必要になったら PVC に差し替える。
+            - name: data
+              mountPath: /var/lib/grafana
+
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-providers
+          configMap:
+            name: grafana-dashboard-providers
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+        - name: data
+          emptyDir: {}

--- a/search/grafana/k8s/namespace.yaml
+++ b/search/grafana/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bbs-grafana

--- a/search/grafana/k8s/service.yaml
+++ b/search/grafana/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app: bbs-grafana
+spec:
+  # クラスタに Ingress がないので NodePort で公開。
+  # リバースプロキシ等で受ける場合は ClusterIP に変更する。
+  type: NodePort
+  selector:
+    app: bbs-grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      nodePort: 30300

--- a/search/grafana/kustomization.yaml
+++ b/search/grafana/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: bbs-grafana
+
+resources:
+  - k8s/namespace.yaml
+  - k8s/deployment.yaml
+  - k8s/service.yaml
+
+configMapGenerator:
+  - name: grafana-datasources
+    files:
+      - provisioning/datasources/postgres.yml
+  - name: grafana-dashboard-providers
+    files:
+      - provisioning/dashboards/dashboards.yml
+  - name: grafana-dashboards
+    files:
+      - dashboards/bbs-posts.json

--- a/search/grafana/provisioning/dashboards/dashboards.yml
+++ b/search/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: bbs
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/search/grafana/provisioning/datasources/postgres.yml
+++ b/search/grafana/provisioning/datasources/postgres.yml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+datasources:
+  - name: BBS Postgres
+    uid: bbs-postgres
+    type: postgres
+    access: proxy
+    url: $POSTGRES_HOST
+    user: $POSTGRES_USER
+    secureJsonData:
+      password: $POSTGRES_PASSWORD
+    jsonData:
+      database: $POSTGRES_DB
+      sslmode: $POSTGRES_SSLMODE
+      maxOpenConns: 5
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+      postgresVersion: 1500
+    isDefault: true
+    editable: false

--- a/search/grafana/setup/readonly-user.sql
+++ b/search/grafana/setup/readonly-user.sql
@@ -1,0 +1,10 @@
+-- Grafana からの接続用の読み取り専用ユーザー。
+-- 匿名公開する Grafana は Postgres データソース経由で任意の SELECT を
+-- 実行できてしまう可能性があるため、必ずこの専用ユーザーを使うこと。
+-- パスワードを変更してから実行する:
+--   psql "$DATABASE_URL" -f readonly-user.sql
+
+CREATE ROLE grafana_reader LOGIN PASSWORD 'CHANGE_ME';
+
+GRANT USAGE ON SCHEMA public TO grafana_reader;
+GRANT SELECT ON res, oekaki TO grafana_reader;

--- a/search/grafana/setup/readonly-user.sql
+++ b/search/grafana/setup/readonly-user.sql
@@ -4,7 +4,12 @@
 -- パスワードを変更してから実行する:
 --   psql "$DATABASE_URL" -f readonly-user.sql
 
-CREATE ROLE grafana_reader LOGIN PASSWORD 'CHANGE_ME';
+CREATE ROLE grafana_reader LOGIN PASSWORD 'CHANGE_ME' CONNECTION LIMIT 10;
 
 GRANT USAGE ON SCHEMA public TO grafana_reader;
 GRANT SELECT ON res, oekaki TO grafana_reader;
+
+-- 匿名ユーザーは任意の SELECT を投げられるため、重いクエリ
+-- (pg_sleep や巨大な JOIN など)で DB を占有されないように制限する。
+ALTER ROLE grafana_reader SET statement_timeout = '10s';
+ALTER ROLE grafana_reader SET idle_in_transaction_session_timeout = '10s';

--- a/search/migrations/20260719000000_add_datetime_index.sql
+++ b/search/migrations/20260719000000_add_datetime_index.sql
@@ -1,2 +1,5 @@
--- Grafana ダッシュボードの期間集計クエリ用に datetime のインデックスを追加
-CREATE INDEX IF NOT EXISTS idx_res_datetime ON res (datetime);
+-- no-transaction
+-- Grafana ダッシュボードの期間集計クエリ用に datetime のインデックスを追加。
+-- crawler の INSERT をブロックしないよう CONCURRENTLY でビルドする
+-- (そのためトランザクション外で実行する必要がある)。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_res_datetime ON res (datetime);

--- a/search/migrations/20260719000000_add_datetime_index.sql
+++ b/search/migrations/20260719000000_add_datetime_index.sql
@@ -1,0 +1,2 @@
+-- Grafana ダッシュボードの期間集計クエリ用に datetime のインデックスを追加
+CREATE INDEX IF NOT EXISTS idx_res_datetime ON res (datetime);


### PR DESCRIPTION
## 概要

投稿量を公開できる Grafana ダッシュボード構成を `search/grafana/` に追加。

- 匿名ユーザーは Viewer として閲覧可能(公開用)。ID をテキストボックスで指定して絞り込める(空欄で全体)
- パネル: 期間内の投稿数 / ユニークID数 / 投稿数の推移 / 投稿数ランキング Top 20 / 時間帯別の投稿数
- docker-compose と kustomize (k8s) の両対応。provisioning とダッシュボード JSON は共通ファイルなので二重管理なし
- 公開時の安全対策として読み取り専用 DB ユーザー (`setup/readonly-user.sql`) を使用。ID 入力は `${id:sqlstring}` でエスケープ
- `res(datetime)` のインデックスを追加するマイグレーションを同梱

## 動作確認

- ローカルで Grafana 12.4.3 + テスト用 Postgres を起動し、匿名アクセスでのダッシュボード取得・時系列集計・ID 絞り込み・ランキングが期待どおり動作することを API で確認
- 読み取り専用ユーザーにより匿名経由の `DELETE` が `permission denied` で拒否されることを確認
- `kubectl kustomize` でのビルドと `kubectl apply --dry-run=client` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)