### PR TITLE
fix(frontend): raise light-theme text contrast to WCAG AA

### DIFF
--- a/search/frontend/src/index.css
+++ b/search/frontend/src/index.css
@@ -12,15 +12,18 @@
     --fill-strong: rgba(120, 120, 128, 0.2);
     --separator: rgba(60, 60, 67, 0.12);
     --label: #1d1d1f;
-    --label-secondary: rgba(60, 60, 67, 0.64);
-    --label-tertiary: rgba(60, 60, 67, 0.4);
-    --accent: #007aff;
-    --accent-soft: rgba(0, 122, 255, 0.12);
-    --accent-ring: rgba(0, 122, 255, 0.35);
+    /* Opacities chosen so 13-15px text clears WCAG AA (4.5:1) on the
+       #f5f5f7 canvas: secondary ~6.0:1, tertiary ~4.5:1. */
+    --label-secondary: rgba(60, 60, 67, 0.82);
+    --label-tertiary: rgba(60, 60, 67, 0.72);
+    /* Apple's link blue; ~5.1:1 on canvas where #007AFF only reaches ~3.7:1 */
+    --accent: #0066cc;
+    --accent-soft: rgba(0, 102, 204, 0.12);
+    --accent-ring: rgba(0, 102, 204, 0.35);
     --highlight: rgba(255, 214, 10, 0.16);
     --yellow: #b25000;
     --yellow-soft: rgba(255, 159, 10, 0.12);
-    --red: #ff3b30;
+    --red: #d70015;
     --red-soft: rgba(255, 59, 48, 0.1);
   }
 


### PR DESCRIPTION
## Summary

#81 への Codex レビュー (P2: ライトテーマの文字コントラスト不足) 対応。

- `--label-secondary` を rgba(60,60,67,0.82) に (3.68:1 → **5.98:1**)
- `--label-tertiary` を rgba(60,60,67,0.72) に (2.10:1 → **4.53:1**)
- `--accent` を Apple のリンクブルー `#0066CC` に (3.69:1 → **5.11:1**、プライマリボタンの白文字も 3.98:1 → **5.57:1**)
- 同じ問題クラスだった `--red` もアクセシブル版 `#D70015` に (≈3.3:1 → **4.94:1**)
- ダークテーマは指摘どおり変更なし

比率は #f5f5f7 キャンバス基準で算出 (WCAG AA 4.5:1、スクリプトで検証済み)。

## Test plan

- [x] `npm run lint` / `npm run build` パス
- [x] 全新色のコントラスト比をスクリプトで検証
- [x] ライトテーマをスクリーンショットで目視確認 (Apple トーンは維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)